### PR TITLE
feat: add Under the Hood section to README and landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **`/unlost-walkthrough` skill**: Installs a walkthrough skill for both OpenCode and Claude Code that guides users through recent changes step-by-step (with VSCode `code --goto` navigation).
+- **"Under the Hood" section**: Added to both `README.md` and `docs/index.html` — a grouped inventory of every technique, algorithm, and strategy Unlost uses (trajectory sensing, emotion/NLP, retrieval/memory, storage/infrastructure), with "where it's used" context on the landing page.
 
 ### Changed
 - **`unlost pr-comment` dual-audience comment**: The comment now serves both the author (staying close to code written by AI agents) and the reviewer. Voice changed from "you" to "we". New sections: "What we were navigating" (shared tradeoff framing with emotional signal woven in), "Ripple effects" (functional knock-on effects across commands/features, not just code imports), "Left open" (deferred decisions, open questions, unresolved next_steps from capsules), and "Re-read this" (1-2 linked file:function pointers to non-obvious logic). File references are now clickable GitHub blob links built from the head SHA and repo coordinates. "How To Verify" removed. Em-dashes banned from output. A blockquote hook at the top of every comment shows the decision count and explains what unlost does; if no decisions were found, it says so plainly and suggests a replay command. Fixed: `headRepositoryOwner` is now fetched as a top-level field (the nested `headRepository.owner.login` path was always empty).

--- a/README.md
+++ b/README.md
@@ -262,6 +262,52 @@ Everything unlost stores stays on your machine:
 
 The only network call unlost makes is to the LLM provider you configure for extraction. That LLM sees only the exchange text (no tool outputs), and it produces a capsule that never goes back upstream.
 
+## Under the Hood
+
+### Trajectory Sensing
+
+- **Three-state FSM** — Stable → Watch → Intervene controller with hysteresis, per-basin cooldowns, and a one-shot rule preventing repeat intervention types
+- **Weighted multi-channel basin scoring** — Loop, Spec, and Drift intensities computed as calibrated weighted sums of 10 independent symptom channels
+- **EMA smoothing** — All 10 channels smoothed with exponential moving average (α=0.3) to suppress single-turn noise spikes
+- **Sliding window persistence** — State only escalates after 3 consecutive turns above the 0.75 intensity threshold
+- **Coffee Pause soft decay** — >30-minute gaps decay intensity to 0.3× and reset state; injects a resumption brief on return
+- **Grounding stall detection** — User-mentioned file paths tracked with exponential time decay; stall streak increments when the agent ignores them
+- **Jaccard-like logic churn** — Word-set distance between consecutive agent decisions; detects rapid plan changes without progress
+- **Symbol repetition / novelty collapse** — Fraction of current capsule symbols seen in the last 8 capsules; complement is novelty score
+- **Stubbornness boost** — Extra intensity when alignment debt is high but decision churn is low (agent acknowledges errors but keeps the same plan)
+- **Blind Acceptance risk** — Detects fluent long responses followed by passive short user replies; flags over-trust risk
+- **Summary intent damping** — Multiplies intensity by 0.6 on turns the agent is legitimately consolidating, preventing false positives
+- **Stratified intervention policy** — Ambient hint / Structural note / Emergency hard-stop tiered by intensity level
+- **Hydration packet** — For Loop interventions, injects the 3 most relevant recent capsules scored by recency, symbol overlap, emotion, effort, and failure mode
+
+### Emotion & NLP
+
+- **Multi-label emotion classification** — RoBERTa-base fine-tuned on GoEmotions (28 labels → 8 buckets), running locally via ONNX Runtime
+- **Heuristic emotion override** — Pattern-based frustration and doubt detection that corrects misclassifications from the neural model
+- **Affective modulation** — Joy halves trajectory intensity; persistent anger triggers a de-escalation override regardless of basin state
+
+### Retrieval & Memory
+
+- **HyPE** — At indexing time, the LLM generates 2–3 questions each capsule answers; at retrieval time, each command frames your query to match those questions — question-to-question match, not keyword-to-document. ([Ma et al., 2025](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5139335))
+- **Trajectory-encoded embeddings** — Each capsule is embedded with its category, failure mode, symbols, and the prior decision from the same work thread; causally related capsules cluster together across sessions
+- **BGE-small-en-v1.5 dense embeddings** — 384-dimensional vectors, generated fully locally via fastembed + ONNX Runtime
+- **ANN vector search** — LanceDB `nearest_to` with an auto-tuned approximate nearest-neighbour index on the embedding column
+- **LabelList index** — Scalar index on the symbols array column enabling fast `array_contains` fan-out queries
+- **Causal chain algorithm** — ANN seed → symbol fan-out via LabelList index → similarity threshold pruning → chronological sort; powers `trace`
+- **Cross-session recurrence scoring** — Capsules scored for `brief` by failure mode, explicit rationale/decision, and symbols recurring across multiple sessions (no recency bias)
+- **Recency-weighted fingerprint deduplication** — `recall` collapses near-duplicates by content fingerprint and caps older sessions at 3 results, with a 30-minute recency bypass
+- **Checkpoint summarization** — Background process compresses windows of capsules into narrative checkpoints; `recall` and `brief` use a fast path when the delta since last checkpoint is small
+
+### Storage & Infrastructure
+
+- **Apache Arrow / LanceDB columnar store** — Capsules stored as Arrow RecordBatches with three indexes (ANN, LabelList, scalar timestamp); append-only with schema evolution
+- **Code graph analysis** — `unfault-core` + petgraph builds a live static graph for centrality scoring, dependency/impact traversal, and symbol validation backing Drift detection
+- **LLM structured extraction** — JSON Schema extraction via rig-core + schemars; produces typed `IntentCapsule` structs from raw agent exchanges
+- **Hybrid extraction mode** — Heuristics identify "pivotal" turns before invoking the LLM, reducing extraction cost by skipping routine turns
+- **SHA-256 job deduplication** — Flush jobs hashed by content; identical jobs within a 45-second window are suppressed
+- **Git grounding & SHA provenance** — Git HEAD and commit SHAs stored on every capsule; git commits ingested as first-class capsules, deduplicated by hash
+- **Changelog ingestion** — CHANGELOG.md versions parsed and stored as versioned capsules, surfaced with `ref=version:vX.Y.Z` citations in LLM prompts
+
 ## License
 
 MIT. See [LICENSE](LICENSE) for details.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1097,6 +1097,179 @@ unlost config llm anthropic --model claude-3-5-sonnet-20241022</code></pre>
     </div>
   </section>
 
+  <!-- Under the Hood -->
+  <section class="section border-t border-midnight-violet-950/5">
+    <div class="container-narrow">
+      <h2 class="text-2xl sm:text-3xl font-medium mb-4 flex items-baseline flex-wrap gap-2">
+        Under the Hood
+        <span class="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-fiery-terracotta mt-1"></span>
+      </h2>
+      <p class="text-lg text-midnight-violet-950/60 mb-10 leading-relaxed">
+        Every sensor, retrieval strategy, and storage primitive that makes Unlost work.
+      </p>
+
+      <div class="space-y-14">
+
+        <!-- Trajectory Sensing -->
+        <div>
+          <h3 class="text-xs font-semibold text-midnight-violet-950/30 mb-6 uppercase tracking-wider">Trajectory Sensing</h3>
+          <div class="space-y-5">
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Three-state FSM</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Stable → Watch → Intervene controller with hysteresis and per-basin cooldowns. Powers every proactive intervention.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Weighted multi-channel basin scoring</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Loop, Spec, and Drift intensities are calibrated weighted sums of 10 independent symptom channels — the signal that drives <code>metrics</code> and all interventions.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">EMA smoothing</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">All 10 channels smoothed with exponential moving average (α=0.3) to suppress single-turn noise spikes before scoring.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Sliding window persistence</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">State only escalates after 3 consecutive turns above the 0.75 threshold — one-turn spikes never trigger an intervention.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Coffee Pause soft decay</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">&gt;30-minute gaps decay intensity to 0.3× and reset the FSM to Stable. On return, a resumption brief is injected to re-orient the agent — used by the trajectory controller and <code>brief</code>.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Grounding stall detection</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">User-mentioned file paths are tracked with exponential time decay; a stall streak increments whenever the agent's response ignores them. Feeds the Drift basin.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Jaccard-like logic churn</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Word-set distance between consecutive agent decisions detects rapid plan changes without progress. Feeds the Loop basin and the Stubbornness boost.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Symbol repetition / novelty collapse</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Fraction of capsule symbols seen in the last 8 capsules; its complement is the novelty score. Both feed the Loop basin and are visible in <code>metrics</code>.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Stubbornness boost</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Extra intensity when alignment debt is high but decision churn is low — the agent acknowledges errors but keeps the same plan. Triggers a Spec-basin escalation.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Blind Acceptance risk</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Detects fluent long agent responses followed by passive short user replies; flags over-trust risk and boosts Spec intensity before an intervention fires.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Summary intent damping</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Multiplies raw intensity by 0.6 on turns the agent is legitimately consolidating — prevents false positives during wrap-up phases.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Stratified intervention policy</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Ambient hint (&lt;0.8), Structural note (≥0.8), Emergency hard-stop (&gt;0.95) — intervention severity scales with signal confidence.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Hydration packet</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">For Loop interventions, the 3 most relevant recent capsules are selected by scoring recency, symbol overlap, emotion, effort, and failure mode — injected into the intervention text to help the agent break the loop.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Emotion & NLP -->
+        <div>
+          <h3 class="text-xs font-semibold text-midnight-violet-950/30 mb-6 uppercase tracking-wider">Emotion &amp; NLP</h3>
+          <div class="space-y-5">
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Multi-label emotion classification</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">RoBERTa-base fine-tuned on GoEmotions (28 labels → 8 buckets), running fully locally via ONNX Runtime. Feeds affective modulation and Spec basin scoring.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Heuristic emotion override</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Pattern-based frustration and doubt detection corrects neural model misclassifications — sarcasm, repetition complaints, and hedging phrases are caught even when the model doesn't fire.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Affective modulation</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Joy halves trajectory intensity. Persistent anger across ≥2 turns triggers a de-escalation override that fires regardless of basin state — based on <a href="https://dl.acm.org/doi/full/10.1145/3756681.3756951" class="text-fiery-terracotta hover:underline">EASE'25</a> research on emotional strain in LLM interactions.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Retrieval & Memory -->
+        <div>
+          <h3 class="text-xs font-semibold text-midnight-violet-950/30 mb-6 uppercase tracking-wider">Retrieval &amp; Memory</h3>
+          <div class="space-y-5">
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">HyPE — Hypothetical Prompt Embeddings</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">At indexing time, the LLM generates 2–3 questions each capsule answers. At retrieval time, <code>recall</code>, <code>trace</code>, <code>challenge</code>, <code>explore</code>, and <code>brief</code> each frame your query as a matching question before embedding — turning retrieval into a question-to-question match with no extra LLM cost. <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5139335" class="text-fiery-terracotta hover:underline" target="_blank" rel="noopener">Ma et al., 2025</a>.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Trajectory-encoded embeddings</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Each capsule is embedded with its category, failure mode, symbols, and the prior decision from the same work thread. Causally related capsules cluster together across sessions — used by every retrieval command.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">BGE-small-en-v1.5 dense embeddings</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">384-dimensional vectors generated fully locally via fastembed + ONNX Runtime. Never sent to a remote service.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">ANN vector search</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">LanceDB <code>nearest_to</code> with an auto-tuned approximate nearest-neighbour index on the embedding column. The seed step in every retrieval command.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">LabelList index</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Scalar index on the symbols array column enabling fast <code>array_contains</code> fan-out queries — used by <code>trace</code> to expand the causal chain.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Causal chain algorithm</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">ANN seed → symbol fan-out via LabelList index → similarity threshold pruning → chronological sort. Powers <code>trace</code> to reconstruct the sequence of decisions that explain the current state of any file or concept.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Cross-session recurrence scoring</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Capsules scored for <code>brief</code> by failure mode weight, explicit rationale and decision presence, and symbols recurring across multiple distinct sessions — with no recency bias.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Recency-weighted fingerprint deduplication</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed"><code>recall</code> collapses near-duplicates by content fingerprint and caps older sessions at 3 results, with a 30-minute recency bypass for fresh capsules.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Checkpoint summarization</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">A background process compresses windows of capsules into narrative checkpoints. <code>recall</code> and <code>brief</code> use a fast path when the delta since the last checkpoint is small — reducing LLM token cost significantly.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Storage & Infrastructure -->
+        <div>
+          <h3 class="text-xs font-semibold text-midnight-violet-950/30 mb-6 uppercase tracking-wider">Storage &amp; Infrastructure</h3>
+          <div class="space-y-5">
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Apache Arrow / LanceDB columnar store</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Capsules stored as Arrow RecordBatches with three indexes (ANN, LabelList, scalar timestamp). Append-only with schema evolution — the foundation every command reads from.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Code graph analysis</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed"><a href="https://github.com/unfault/core" class="text-fiery-terracotta hover:underline font-mono text-sm">unfault-core</a> + petgraph builds a live static graph for centrality scoring, dependency/impact traversal, and symbol validation — used by <code>brief</code> to expand scope and by Drift detection to validate agent-mentioned identifiers.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">LLM structured extraction</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">JSON Schema extraction via rig-core + schemars produces typed <code>IntentCapsule</code> structs from raw agent exchanges. Works with any provider — Anthropic, OpenAI, Ollama.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Hybrid extraction mode</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Heuristics identify "pivotal" turns before invoking the LLM — routine exchanges are skipped, reducing extraction cost without losing signal.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">SHA-256 job deduplication</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Flush jobs hashed by content; identical jobs within a 45-second window are suppressed. Also used to derive stable workspace IDs from git remote URLs.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Git grounding &amp; SHA provenance</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Git HEAD and commit SHAs stored on every capsule. Git commits ingested as first-class capsules deduplicated by hash — surfaced by <code>brief</code>, <code>trace</code>, <code>challenge</code>, and <code>explore</code>.</p>
+            </div>
+            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Changelog ingestion</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">CHANGELOG.md versions parsed and stored as versioned capsules, surfaced with <code>ref=version:vX.Y.Z</code> citations in LLM prompts — used by <code>challenge</code> and <code>brief</code> for version-aware context.</p>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
   <!-- Who's Behind This -->
   <section class="section">
     <div class="container-narrow">


### PR DESCRIPTION
## Summary
- Adds a new `## Under the Hood` section to `README.md` before the License, listing 30+ techniques across four groups: Trajectory Sensing, Emotion & NLP, Retrieval & Memory, Storage & Infrastructure
- Adds a matching `<section>` to `docs/index.html` with the same four groups, each entry including a "where it's used" sentence pointing to the relevant commands or subsystem
- Gives users a clear, scannable answer to "what's actually in this?" without changing any code

## Changelog
- **"Under the Hood" section**: Added to both `README.md` and `docs/index.html` — a grouped inventory of every technique, algorithm, and strategy Unlost uses (trajectory sensing, emotion/NLP, retrieval/memory, storage/infrastructure), with "where it's used" context on the landing page.