### PR TITLE
feat: refactor readme structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+- **README**: Restructured for better readability, moving installation to top and collapsing technical details.
+
+
 ## [0.11.0] - 2026-02-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,78 +34,52 @@ Unlost intercepts before you pay. It detects these failure modes and guides agen
 | **False Progress** | Agent claims done. Verification would fail. | Detects the claim and flags it for review. |
 | **Unbounded Horizon** | Agent wanders into unrelated side-quests. | Nudges back toward the original goal. |
 
-## Use unlost with your favourite agent
+## Install
 
-### Claude
+```bash
+curl -fsSL https://unlost.unfault.dev/install.sh | bash
+```
 
-All your Claude Code projects, forever, with zero per-repo config:
+Or download the binary manually from [releases](https://github.com/unfault/unlost/releases).
 
+## Quick Start
+
+### 1. Hook into your agent
+
+**Claude Code** (Global, zero per-repo config):
 ```bash
 unlost config agent claude --global
 ```
 
-This installs the Unlost agent skill and hooks unlost into every Claude Code session. Unlost checks for friction before each prompt, injects guidance when something feels off, and quietly records what actually happened (intent, decision, rationale, next steps) into local capsules you can query anytime.
-
-### OpenCode
-
-All your OpenCode projects (global config):
-
+**OpenCode** (Global):
 ```bash
 unlost config agent opencode --global
 ```
+Or per-project: `unlost config agent opencode --path .`
 
-Or one project at a time:
-
-```bash
-unlost config agent opencode --path .
-```
-
-This installs the Unlost agent skill and hooks unlost into your OpenCode sessions. The skill teaches OpenCode:
-
-- **Friction detection** runs automatically — unlost checks for drift, retry spirals, and false progress before each prompt
-- **Two tiers of memory commands**:
-  - Fast path (no LLM): `unlost metrics` — safe to run proactively
-  - LLM path (on demand): `unlost recall`, `unlost brief`, `unlost trace`, `unlost challenge`, `unlost explore` — only when user explicitly asks
-
-Unlost spots drift, catches false progress, and builds a local trail of decisions — without storing full transcripts.
-
-## How it works
-
-```
-1. Your agent is about to send a prompt → unlost checks for friction
-2. If something feels off → injects guidance before the agent goes off-track
-3. After each exchange → extract a capsule (what we tried, why, next steps)
-4. Capsules stay local → query anytime: "why did we do X?"
-```
-
-No transcripts. No external storage. Just small, queryable capsules that remember what your agents decided and why.
-
-## Configure your LLM (optional, for better capsules)
-
-Unlost uses a small LLM to extract structured capsules from agent exchanges. By default, it uses whatever LLM your agent is already configured with. You can override this for better results:
+### 2. (Optional) Configure extraction LLM
+By default, unlost uses whatever LLM your agent is configured with. You can override this for better results (e.g., using a smaller/faster model for extraction):
 
 ```bash
-# Use Claude for extraction
-unlost config llm anthropic --model claude-sonnet-4-5-20250929
+# Use Claude
+unlost config llm anthropic --model claude-3-5-sonnet-20241022
 
 # Or OpenAI
 unlost config llm openai --model gpt-4o-mini
 ```
 
-**What the LLM is fed:**
-- The raw user → assistant exchange (just the text, not tool outputs)
-- Recent capsule history from the workspace (to detect contradictions)
+## How it works
 
-**What it produces:**
-- A structured capsule with: category, intent, decision, rationale, next_steps, symbols, failure_mode
+1. **Check:** Your agent is about to send a prompt → unlost checks for friction (drift, loops, etc.).
+2. **Guide:** If something feels off → injects guidance before the agent goes off-track.
+3. **Capture:** After each exchange → extracts a structured capsule (intent, decision, rationale).
+4. **Recall:** Capsules stay local → query anytime: "why did we do X?"
 
-**Where it runs:**
-- The LLM call goes through your configured provider (Anthropic, OpenAI, etc.)
-- Capsule storage is entirely local — embeddings, the capsules themselves, and query history never leave your machine
+## Features
 
-## Memory Commands
+### Memory Commands
 
-Your agents built a memory trail. Here's how to use it:
+Your agents build a memory trail. Here's how to use it:
 
 ```bash
 # Get a staff engineer's debrief — what matters, what bites, where to start
@@ -117,139 +91,47 @@ unlost brief src/governor.rs
 # What happened recently in this file?
 unlost recall src/http_proxy.rs
 
-# Reconstruct the causal chain that led to the current state of a file
+# Reconstruct the causal chain that led to the current state
 unlost trace src/governor.rs
-
-# Ask a question about a decision's history
 unlost trace "why is the connection timeout 30 seconds?"
 
-# Investigate what happened in a specific time window
-unlost trace "auth flow" --since 4M --until 3M
-
 # Pressure-test a past technology choice
-unlost challenge "lancedb"
 unlost challenge "was using fastembed the right call?"
 
 # Explore future paths grounded in workspace memory
 unlost explore "should we keep lancedb or move to sqlite+fts?"
-unlost explore "what would multi-workspace federation require?"
 ```
 
-### `unlost brief`
+#### Key Commands Explained:
+- **`unlost brief`**: A one-command orientation for any codebase. Answers "Here's what this system is, the non-obvious choices, and where to start reading." Scans all recorded memory and git commits.
+- **`unlost trace`**: Reconstructs the **causal chain** of decisions. Unlike `recall` (which narrates recent history), `trace` asks: *why is the code the way it is?* It builds a chronological chain seeded by semantic similarity.
 
-`brief` is a one-command orientation for any codebase you didn't write (or haven't touched in a while). It answers the question a staff engineer would answer on day one: *"Here's what this system is, the non-obvious choices, the things that bite, and where to start reading."*
+### The Cognitive Mirror (Metrics)
 
-Unlike `recall` (which narrates recent history), `brief` scans all recorded memory — conversations and git commits — and scores each capsule by importance: failure modes that were recorded, decisions with rationale, knowledge that surfaced repeatedly across sessions. The output is structured into four sections:
-
-```
-MENTAL MODEL          — what this system is and its core invariant
-KEY DESIGN DECISIONS  — non-obvious choices and why they were made
-THINGS THAT BITE      — gotchas and hard-learned lessons
-ENTRY POINTS          — where to start reading, with file:line references
-GO DEEPER             — suggested unlost commands to drill down further
-```
-
-Git commit messages are first-class capsules in `brief`. A commit like `"fix: workspace ID must come from git remote, not path"` with an explanatory body will surface as a KEY DESIGN DECISION — even if it predates when you started using unlost.
-
-### `unlost trace`
-
-`trace` reconstructs the **causal chain** of decisions that explain the current state of a file, symbol, or concept. Where `recall` narrates what happened recently, `trace` asks: *why is the code the way it is?*
-
-Pass a file path, a function name, or a natural-language question. Unlost builds a chronological chain — seeded by semantic similarity, expanded by symbol overlap — and narrates the path: the turning points, the recorded failures, the constraint that became an invariant.
-
-```bash
-# The path that led to this file's current state
-unlost trace src/http_proxy.rs
-
-# Why a specific decision was made
-unlost trace "why did we switch to HTTP/2?"
-
-# Incident investigation: what happened in a specific window?
-unlost trace "connection timeout" --since 4M --until 3M
-```
-
-This works across session boundaries and across months of history. Engineers don't slice their work neatly per session — `trace` doesn't require them to.
-
-## Long Memory & the Story Arc
-
-Capsules are not just a log. They encode a *causal history* — the sequence of decisions, constraints, and failures that explain why the code looks the way it does today.
-
-### How it works
-
-**Richer embeddings.** Every capsule is embedded with its category, failure mode, top symbols, and the prior decision from the same work thread. This encodes trajectory into the vector — capsules from the same causal chain cluster together in embedding space, even across different sessions.
-
-**HyPE questions.** When a capsule is extracted, the LLM also generates 2–3 questions the capsule answers — *"Why is the timeout 30 seconds?"*, *"How does the proxy route upstream requests?"*. At retrieval time, each command frames your input as a question matching the command's intent before embedding it — `recall` wraps your target as *"What happened with X?"*, `challenge` as *"Was the decision about X the right call?"*, and so on. This turns retrieval into a question-to-question match against the stored HyPE questions, dramatically improving precision with zero extra LLM cost. Based on [Ma et al., "HyPE: Hypothetical Prompt Embeddings" (2025)](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5139335).
-
-**Causal chain (trace).** `unlost trace` seeds from a vector search, fans out to capsules sharing symbols, applies a similarity threshold, and sorts the survivors chronologically. The LLM narrates the causal path: turning points, recorded failures, the constraint that became an invariant.
-
-```
-2026-01-14  switched to HTTP/2 for upstream
-2026-01-21  retry spiral on keepalive — increased timeout to 30s
-2026-02-03  timeout 30s hardcoded in proxy_request
-2026-02-18  ← you are here
-```
-
-### Already have capsules?
-
-New capsules automatically get richer embeddings and HyPE questions. To apply these improvements to your existing history, run `unlost reindex`.
-
-## The Cognitive Mirror (Metrics)
-
-Unlost doesn't just store memory; it tracks the **trajectory** of your collaboration. As context grows, agents often begin to stall or drift. Unlost monitors these patterns across three "Basins of Friction":
-
-| Basin | What it senses | Leading Indicator |
-|-------|----------------|-------------------|
-| **Loop** | Repetitive stalls | Symbol repetition, novelty collapse, logic churn. |
-| **Spec** | Alignment debt | VERBATIM instruction repeats, corrective keywords. |
-| **Drift** | Grounding failure | Hallucinated paths, ignoring user-mentioned files. |
-
-Use the `metrics` command to see the "Cognitive Mirror" of your workspace:
+Unlost tracks the **trajectory** of your collaboration. Use `metrics` to see friction points:
 
 ```bash
 unlost metrics
 ```
 
 This reveals:
-- **Friction vs Context Size**: See how the warning rate spikes as your input tokens grow (the "Lost in Context" threshold).
-- **Average Verbosity**: Measures "Fluency" — how much the assistant is dominating the token share (a leading indicator for over-trust and blind acceptance).
-- **Average Interval**: How many tokens of productive work you get between trajectory breakdowns.
-- **Top Friction Files**: Codebase "hotspots" that are consistently causing the agent to stall or drift.
+- **Friction vs Context Size**: When does the agent get lost?
+- **Average Verbosity**: A leading indicator for over-trust.
+- **Top Friction Files**: Codebase "hotspots" causing stalls.
 
-## Replay & Git History
+### Replay & Git History
 
-Did an agent session happen while Unlost was off? Or do you want to seed a codebase with its git history?
+Seed your memory from past sessions or git history:
 
 ```bash
-# Replay OpenCode sessions — also ingests git history automatically
+# Replay OpenCode sessions (ingests git history automatically)
 unlost replay opencode
 
-# Replay a Claude transcript — also ingests git history automatically
+# Replay a Claude transcript
 unlost replay claude --transcript-path history.json
 
-# Ingest only git history (no agent transcript needed)
-unlost replay git
+# Ingest only git history
 unlost replay git --max-commits 200
-```
-
-Git commit history is ingested automatically whenever you run `replay opencode` or `replay claude` — no extra step. Each commit becomes a capsule: subject as the decision, body as the rationale, touched files as symbols. Deduplication by hash means re-running replay never double-counts commits.
-
-The `--git-grounding` flag (on `replay opencode` and `replay claude`) cross-references agent-touched files against actual commits in your history, marking capsules as "Verified via Git" when a match is found.
-
-Git capsules are used by `brief`, `challenge`, `explore`, and `trace` but deliberately excluded from `recall` (which stays focused on the conversational story) and from the trajectory controller (which operates on live turns only).
-
-## Install
-
-```bash
-curl -fsSL https://unlost.unfault.dev/install.sh | bash
-```
-
-Or download the binary manually from [releases](https://github.com/unfault/unlost/releases).
-
-## Dev
-
-```bash
-cargo test
-cargo build
 ```
 
 ## Privacy First
@@ -262,7 +144,8 @@ Everything unlost stores stays on your machine:
 
 The only network call unlost makes is to the LLM provider you configure for extraction. That LLM sees only the exchange text (no tool outputs), and it produces a capsule that never goes back upstream.
 
-## Under the Hood
+<details>
+<summary><h2>Under the Hood (Technical Details)</h2></summary>
 
 ### Trajectory Sensing
 
@@ -307,6 +190,15 @@ The only network call unlost makes is to the LLM provider you configure for extr
 - **SHA-256 job deduplication** — Flush jobs hashed by content; identical jobs within a 45-second window are suppressed
 - **Git grounding & SHA provenance** — Git HEAD and commit SHAs stored on every capsule; git commits ingested as first-class capsules, deduplicated by hash
 - **Changelog ingestion** — CHANGELOG.md versions parsed and stored as versioned capsules, surfaced with `ref=version:vX.Y.Z` citations in LLM prompts
+
+</details>
+
+## Dev
+
+```bash
+cargo test
+cargo build
+```
 
 ## License
 


### PR DESCRIPTION
## Summary
- Moved `Install` section to the top for better UX.
- Grouped feature commands (`Memory`, `Metrics`, `Replay`) into a unified `Features` section.
- Collapsed dense technical details ("Under the Hood") using `<details>` tag.
- Consolidated agent configuration instructions.

## Changelog
- **README**: Restructured for better readability, moving installation to top and collapsing technical details.