### PR TITLE
fix: enforce 80-col wrapping in unlost checkpoint output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 
 ### Fixed
+- **`unlost checkpoint` output**: Fixed narrative output not wrapping at 80 columns. Now uses `render_narrative` to ensure proper formatting and ANSI coloring.
 - **Recall/inspect filtering bug**: Fixed an issue where `unlost recall` and `unlost inspect` with filters (e.g. `--emotion joy`) would return no results. The optimization to fetch only the most recent rows was calculating the offset based on the total row count instead of the filtered row count, often skipping all matching rows.
 
 ## [0.11.0] - 2026-02-24

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -109,7 +109,10 @@ pub async fn run(
                 println!("  session:  {}", cp.session_id.as_deref().unwrap_or("(all)"));
                 println!("  capsules: {}  |  model: {}", cp.capsule_count, cp.model_used);
                 println!();
-                println!("{}", cp.narrative);
+                println!(
+                    "{}",
+                    crate::narrative::render_narrative(crate::cli::OutputFormat::Ansi, &cp.narrative)
+                );
             }
             Err(reason) => {
                 use crate::storage_checkpoint::CheckpointSkipReason::*;


### PR DESCRIPTION
## Summary
- Modified `unlost checkpoint` to use `render_narrative` for output.
- Ensures narrative text is wrapped at 80 columns and backticks are colorized, matching other commands like `brief` and `recall`.
- Addresses user request for fixed-width output.

## Changelog
- **`unlost checkpoint` output**: Fixed narrative output not wrapping at 80 columns. Now uses `render_narrative` to ensure proper formatting and ANSI coloring.