### PR TITLE
fix: reduce friction detection false positives during productive discussions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Friction detection false positives**: Three targeted changes reduce spurious de-escalation interventions during productive back-and-forth discussions. (1) The `anger_streak` fast path now requires trajectory intensity >= Watch threshold (0.5) in addition to 2+ consecutive negative turns — pure emotion-classification noise can no longer trigger an intervention without corroborating behavioral evidence. (2) The go_emotions `disapproval` label is excluded from the anger streak counter, since it maps to intellectual disagreement rather than user upset; it still contributes to trajectory intensity via valence. (3) The heuristic override that mapped `neutral + 1 frustration signal → disapproval` is removed — a single matched keyword (e.g. `"broken"` in a technical description) is too weak a signal to override a neutral classification.
+
 ### Changed
 - **`README`**: Reframed mission around ownership vs. authorship. The README now leads with the human engineer's perspective — accountability in incidents, reviews, and architecture decisions — rather than agent failure modes. Removed the babysitting tax framing and failure mode table from the lead; commands are now grouped by the moment you reach for them (understanding, deciding, handing off).
 

--- a/src/emotion.rs
+++ b/src/emotion.rs
@@ -409,20 +409,10 @@ fn boost_negative_emotions(text: &str, meta: EmotionMeta) -> EmotionMeta {
         };
     }
 
-    // If model said neutral and we have 1 signal, boost to mild disapproval
-    if meta.label == "neutral" && signal_count == 1 {
-        tracing::debug!(
-            original_label = %meta.label,
-            original_confidence = meta.confidence,
-            "boosting emotion from neutral to disapproval based on text signal"
-        );
-        return EmotionMeta {
-            label: "disapproval".to_string(),
-            valence: -0.4,
-            intensity: 0.4,
-            confidence: 0.5,
-        };
-    }
+    // If model said neutral and we have exactly 1 signal, do not override — one matched
+    // keyword on an otherwise neutral message is too weak a signal (e.g. the word "broken"
+    // in a technical description, or "seriously" as an intensifier in a positive context).
+    // Two signals are required to conclude even mild disapproval (handled above at signal_count >= 2).
 
     meta
 }

--- a/src/governor.rs
+++ b/src/governor.rs
@@ -226,9 +226,12 @@ impl TrajectoryController {
         let s_stat = if self.static_streak >= 2 { 1.0 } else { 0.0 };
 
         // Anger escalation streak: track consecutive turns where the user is angry/frustrated.
+        // Note: "disapproval" is excluded here — it maps to intellectual disagreement in go_emotions
+        // and should not increment the streak. It still affects trajectory intensity via affective
+        // modulation (valence contribution), so it is not ignored entirely.
         let is_angry = matches!(
             current_emotion.map(|e| e.label.as_str()),
-            Some("anger" | "frustration" | "disapproval")
+            Some("anger" | "frustration")
         );
         if is_angry {
             self.anger_streak += 1;
@@ -391,10 +394,11 @@ impl TrajectoryController {
         };
 
         // Anger escalation override: if the user has been angry/frustrated for 2+ consecutive
-        // turns, fire a de-escalation note regardless of the normal trajectory cause.
-        // This short-circuits the basin dispatch so we never instruct the agent to apologize
-        // or keep executing — we want it to stop, acknowledge, and propose a recovery plan.
-        let anger_override = if self.anger_streak >= 2 {
+        // turns AND the trajectory intensity is already elevated (>= Watch threshold), fire a
+        // de-escalation note. The trajectory gate prevents pure emotion-classification noise
+        // (e.g. a fruitful back-and-forth discussion) from triggering this path — there must
+        // be corroborating behavioral evidence before we short-circuit normal dispatch.
+        let anger_override = if self.anger_streak >= 2 && self.intensity >= THRESHOLD_WATCH {
             let key = "anger_escalation";
             if self.basin_cooldowns.get(key).map_or(0, |c| *c) == 0 {
                 self.basin_cooldowns.insert(key.to_string(), 3);


### PR DESCRIPTION
## Summary
- The `anger_streak` fast path now requires trajectory intensity >= 0.5 (Watch threshold) before firing a de-escalation note — emotion classification noise alone can no longer trigger an intervention without corroborating behavioral evidence
- `disapproval` (go_emotions label for intellectual disagreement) removed from the anger streak counter; it still contributes to trajectory intensity via valence modulation
- Removed the `neutral + 1 frustration signal → disapproval` heuristic override — a single matched keyword is too weak a signal to override a neutral classification

## Changelog
- **Friction detection false positives**: Three targeted changes reduce spurious de-escalation interventions during productive back-and-forth discussions. (1) The `anger_streak` fast path now requires trajectory intensity >= Watch threshold (0.5) in addition to 2+ consecutive negative turns — pure emotion-classification noise can no longer trigger an intervention without corroborating behavioral evidence. (2) The go_emotions `disapproval` label is excluded from the anger streak counter, since it maps to intellectual disagreement rather than user upset; it still contributes to trajectory intensity via valence. (3) The heuristic override that mapped `neutral + 1 frustration signal → disapproval` is removed — a single matched keyword (e.g. `"broken"` in a technical description) is too weak a signal to override a neutral classification.