### PR TITLE
feat: restructure docs to prioritize context ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **`docs/index.html`**: Restructured landing page to prioritize Context Ownership and Memory over control. "How It Works" now follows the Memory Lifecycle (Record → Extract → Ground). Added "One Memory. Many Lenses" section to showcase `trace`, `challenge`, and `explore` as different views on the same grounded context. Moved "Cognitive Mirror" technical details to a dedicated deep-dive section at the bottom.
+
 ## [0.11.2] - 2026-02-26
 
 ### Fixed

--- a/docs/index.html
+++ b/docs/index.html
@@ -86,11 +86,8 @@
       <a href="#" class="text-midnight-violet-950 font-medium text-lg">unlost</a>
       <div class="flex items-center gap-2 sm:gap-4">
         <div class="hidden md:flex items-center gap-6 text-sm">
-          <a href="#problem" class="text-midnight-violet-950/70 hover:text-fiery-terracotta transition-colors">Problem</a>
-          <a href="#solution" class="text-midnight-violet-950/70 hover:text-fiery-terracotta transition-colors">Solution</a>
           <a href="#install" class="text-midnight-violet-950/70 hover:text-fiery-terracotta transition-colors">Install</a>
           <a href="#commands" class="text-midnight-violet-950/70 hover:text-fiery-terracotta transition-colors">Commands</a>
-          <a href="#long-memory" class="text-midnight-violet-950/70 hover:text-fiery-terracotta transition-colors">Long Memory</a>
         </div>
         <a href="https://github.com/unfault/unlost" class="inline-flex items-center px-3 py-1.5 sm:px-4 sm:py-2 text-sm font-medium text-white bg-midnight-violet-950 rounded-lg hover:bg-midnight-violet-800 transition-colors">GitHub</a>
       </div>
@@ -112,7 +109,7 @@
   <section class="section pt-24 sm:pt-28 lg:pt-32">
     <div class="container-narrow">
       <h1 class="text-3xl sm:text-4xl md:text-5xl lg:text-6xl mb-4 sm:mb-6 leading-tight font-medium">
-        AI gets code authorship.<br>Context ownership stays with you.
+        AI gets code authorship.<br><span class="text-fiery-terracotta">Context ownership</span> stays with you.
       </h1>
       
       <p class="text-lg sm:text-xl text-midnight-violet-950/60 mb-6 sm:mb-8 leading-relaxed">
@@ -120,6 +117,18 @@
         the context that used to live in your head - and now lives in
         the agent - close to you.
       </p>
+
+      <div class="mb-10 sm:mb-14">
+        <div class="mb-3">
+          <pre class="cursor-pointer hover:bg-midnight-violet-900 transition-colors relative group" onclick="navigator.clipboard.writeText('curl -fsSL https://unlost.unfault.dev/install.sh | bash'); this.querySelector('.copy-msg').classList.remove('opacity-0'); setTimeout(() => this.querySelector('.copy-msg').classList.add('opacity-0'), 2000);"><code>curl -fsSL https://unlost.unfault.dev/install.sh | bash</code><span class="copy-msg absolute right-4 top-1/2 -translate-y-1/2 text-xs text-white/40 opacity-0 transition-opacity">Copied</span></pre>
+        </div>
+        <div class="flex flex-col sm:flex-row sm:items-center justify-between text-xs sm:text-sm text-midnight-violet-950/50 gap-2">
+          <span>For Windows, please download the binary from our <a href="https://github.com/unfault/unlost/releases" class="text-fiery-terracotta hover:underline">releases page</a>.</span>
+          <a href="#install" class="hover:text-fiery-terracotta transition-colors flex items-center gap-1">
+            Setup guide <span class="text-[10px]">↓</span>
+          </a>
+        </div>
+      </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 mb-12 sm:mb-16">
         <div class="rounded-xl border-l-2 border-[#E74F26]/50 p-4 sm:p-5">
@@ -228,346 +237,8 @@
     </div>
   </section>
 
-  <!-- Install -->
-  <section id="install" class="section">
-    <div class="container-narrow">
-      <h2 class="text-2xl sm:text-3xl font-medium mb-8 sm:mb-12 flex items-baseline flex-wrap gap-2">
-        Install 
-        <span class="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-fiery-terracotta mt-1"></span>
-      </h2>
-
-      <div class="space-y-8">
-        <div>
-          <h3 class="text-base sm:text-lg font-semibold mb-4">Get Unlost</h3>
-          <pre class="text-xs sm:text-sm"><code>curl -fsSL https://unlost.unfault.dev/install.sh | bash</code></pre>
-          <small class="text-midnight-violet-950/60 block mt-2 text-sm">For Windows, please download the binary from our <a href="https://github.com/unfault/unlost/releases" class="text-fiery-terracotta hover:underline">releases</a> page.</small>
-        </div>
-
-        <div>
-          <h3 class="text-base sm:text-lg font-semibold mb-4">Agent Integration</h3>
-          <p class="text-midnight-violet-950/60 mb-4">
-            Hook unlost into your agent. This installs the Unlost agent skill (for OpenCode) and configures the necessary hooks. The skill teaches the agent how to use unlost: fast-path commands for proactive checks, and LLM-path commands for on-demand recall. Choose global for system-wide coverage, or per-project for opt-in control.
-          </p>
-          <pre><code># Claude Code - one command, works everywhere
-unlost config agent claudecode --global
-
-# OpenCode - opt-in per repository
-cd your-project
-unlost config agent opencode --path .</code></pre>
-          <small class="text-midnight-violet-950/60 block mt-4 text-sm">
-            <strong>What the skill teaches:</strong> For OpenCode, the installed skill teaches two tiers of commands:
-            <br><br>
-            <strong>Fast path</strong> (no LLM, run proactively): <code>unlost metrics</code>
-            <br>
-            <strong>LLM path</strong> (on demand only): <code>unlost recall</code>, <code>unlost brief</code>, <code>unlost trace</code>, <code>unlost challenge</code>, <code>unlost explore</code>
-          </small>
-          <small class="text-midnight-violet-950/60 block mt-2 text-sm">If you want to use Unlost with your favourite agent, please <a href="https://github.com/unfault/unlost/issues" class="text-fiery-terracotta hover:underline">drop us a note</a>.</small>
-        </div>
-
-        <div>
-          <h3 class="text-base sm:text-lg font-semibold mb-4">Configure Your LLM</h3>
-          <p class="text-midnight-violet-950/60 mb-4">
-            Unlost requires an LLM for capsule extraction and summarization. While friction detection 
-            works locally, a dedicated extraction model dramatically improves capsule quality. 
-            Better structured data means more accurate recall and sharper pattern detection.
-          </p>
-          <pre><code>unlost config llm anthropic --model claude-sonnet-4-5-20250929
-unlost config llm openai --model gpt-4o-mini</code></pre>
-          <small class="text-midnight-violet-950/60 block mt-2 text-sm">
-            <strong>Recommendation:</strong> Use a fast, cheap model like GPT-4o-mini or Claude 3.5 Haiku. 
-            Extraction doesn't need reasoning; just structured output. You'll process thousands of 
-            messages; speed and cost matter more than intelligence.
-          </small>
-        </div>
-
-        <div class="pl-3 sm:pl-4 border-l-4 border-fiery-terracotta">
-          <p class="text-midnight-violet-950/70">
-            That's it. Next time you start your agent, unlost will automatically work alongside it.
-            <span class="text-midnight-violet-950/50">Happy coding!</span>
-          </p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Commands -->
-  <section id="commands" class="section">
-    <div class="container-narrow">
-      <h2 class="text-2xl sm:text-3xl font-medium mb-8 sm:mb-12 flex items-baseline flex-wrap gap-2">
-        Commands 
-        <span class="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-fiery-terracotta mt-1"></span>
-      </h2>
-
-      <div class="space-y-10 sm:space-y-12">
-        <!-- Brief -->
-        <div id="brief">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost brief</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">A staff engineer's debrief on any codebase: what matters, what bites, where to start. Scans all recorded memory (conversations + git commits) and scores by importance, not recency.</p>
-          <pre><code>unlost brief
-unlost brief src/governor.rs
-unlost brief TrajectoryController</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example output</div>
-            <div class="text-white font-bold whitespace-nowrap">MENTAL MODEL</div>
-            <div class="text-white/80 whitespace-nowrap">Unlost is a local-first agent memory tool. The core loop: LLM conversations</div>
-            <div class="text-white/80 whitespace-nowrap">flow through a shim → capsules are extracted and embedded → stored in</div>
-            <div class="text-white/80 whitespace-nowrap">`LanceDB` → surfaced via `recall`, `brief`, and `query`.</div>
-            <div class="text-white font-bold mt-3 whitespace-nowrap">KEY DESIGN DECISIONS</div>
-            <div class="text-white/80 whitespace-nowrap">• `capsules_v3` schema is append-only; mutations require `reindex`</div>
-            <div class="text-white/80 whitespace-nowrap">• `TrajectoryController` is pure Rust, zero LLM; intentional for latency</div>
-            <div class="text-white/80 whitespace-nowrap">• Workspace ID comes from git remote URL, not path</div>
-            <div class="text-white font-bold mt-3 whitespace-nowrap">THINGS THAT BITE</div>
-            <div class="text-white/80 whitespace-nowrap">• Aliased git clones get a different workspace ID; data appears missing</div>
-            <div class="text-white/80 whitespace-nowrap">• `llm_extract` silently falls back to OPENAI_API_KEY if no config set</div>
-            <div class="text-white font-bold mt-3 whitespace-nowrap">ENTRY POINTS</div>
-            <div class="text-white/80 whitespace-nowrap">• `src/companion/flow.rs:414`: main recording pipeline</div>
-            <div class="text-white/80 whitespace-nowrap">• `src/commands/recall.rs:133`: recall entry point</div>
-            <div class="text-white font-bold mt-3 whitespace-nowrap">GO DEEPER</div>
-            <div class="text-cyan-400/70 whitespace-nowrap">  unlost brief src/governor.rs</div>
-            <div class="text-cyan-400/70 whitespace-nowrap">  unlost query "why is workspace ID derived from git remote"</div>
-          </div>
-        </div>
-
-        <!-- Memory -->
-        <div id="recall">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost recall</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Recall the story so far (proactive overview) from a specific file or directory.</p>
-          <pre><code>unlost recall src/http_proxy.rs
-unlost recall src/</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example output</div>
-            <div class="text-white/80 whitespace-nowrap">Overall state for src/http_proxy.rs:</div>
-            <div class="text-white/80 whitespace-nowrap">The project has explicitly removed/deprecated the proxy-based opencode command</div>
-            <div class="text-white/80 whitespace-nowrap">in favor of the plugin/companion workflow, making src/http_proxy.rs likely</div>
-            <div class="text-white/80 whitespace-nowrap">unreachable and non-critical. Current focus should be to confirm its</div>
-            <div class="text-white/80 whitespace-nowrap">reachability and either retire or gate it to reduce complexity.</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">Key decisions:</div>
-            <div class="text-white/80 whitespace-nowrap">- Consolidate CLI to a single `opencode` using `plugin/companion`.</div>
-            <div class="text-white/80 whitespace-nowrap">- Drop proxy-dependent command/wiring (`proxy`, `deprecated`).</div>
-            <div class="text-white/80 whitespace-nowrap">- Treat recall for this file as partially relevant.</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">Suggested next steps:</div>
-            <div class="text-white/80 whitespace-nowrap">- Trace call sites to confirm whether src/http_proxy.rs is still referenced.</div>
-            <div class="text-white/80 whitespace-nowrap">- If unreachable, remove the file and associated proxy dependencies.</div>
-          </div>
-        </div>
-
-        <div id="challenge">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost challenge</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Pressure-test a past decision or technology choice using workspace memory and the live code graph. Concise by default - add <code>--deep</code> for UNKNOWNS and PROBES sections.</p>
-          <pre><code>unlost challenge "lancedb"
-unlost challenge "was using fastembed the right call?"
-unlost challenge "the proxy recorder architecture" --deep</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example: unlost challenge "lancedb"</div>
-            <div class="text-white font-bold whitespace-nowrap">THE DECISION</div>
-            <div class="text-white/80 whitespace-nowrap">LanceDB was chosen as the local vector store for capsule embeddings.</div>
-            <div class="text-white font-bold mt-3 whitespace-nowrap">ALTERNATIVES</div>
-            <div class="text-white/80 whitespace-nowrap">① SQLite + sqlite-vec</div>
-            <div class="text-white/60 whitespace-nowrap">  Upside:   single file, zero native deps</div>
-            <div class="text-white/60 whitespace-nowrap">  Downside: no ANN index, full scan on large workspaces</div>
-            <div class="text-white/80 mt-1 whitespace-nowrap">② Qdrant embedded</div>
-            <div class="text-white/60 whitespace-nowrap">  Upside:   richer filtering and scoring</div>
-            <div class="text-white/60 whitespace-nowrap">  Downside: heavier binary, more complex setup</div>
-            <div class="text-white font-bold mt-3 whitespace-nowrap">VERDICT</div>
-            <div class="text-white/80 whitespace-nowrap">Keep if: ANN performance matters and binary size is acceptable.</div>
-            <div class="text-white/80 whitespace-nowrap">Change if: you need a single-file deploy with zero native deps.</div>
-          </div>
-        </div>
-
-        <div id="explore">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost explore</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Explore future paths grounded in your workspace memory. A thinking partner that labels what comes from memory <code>[memory]</code> vs. external knowledge <code>[outside]</code>.</p>
-          <pre><code>unlost explore "should we keep lancedb or move to sqlite+fts?"
-unlost explore "what would multi-workspace federation require?"
-unlost explore "is our embedding model still the right choice?"</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example: unlost explore "remove the proxy recorder?"</div>
-            <div class="text-white font-bold whitespace-nowrap">CONTEXT FROM MEMORY</div>
-            <div class="text-white/80 whitespace-nowrap">The proxy path was deprecated in favour of the plugin/companion</div>
-            <div class="text-white/80 whitespace-nowrap">architecture. <span class="text-white/40">[memory]</span></div>
-            <div class="text-white font-bold mt-3 whitespace-nowrap">PATHS WORTH CONSIDERING</div>
-            <div class="text-white/80 whitespace-nowrap">• Delete src/http_proxy.rs - already unreachable <span class="text-white/40">[memory]</span></div>
-            <div class="text-white/80 whitespace-nowrap">• Keep hidden behind flag for emergency fallback <span class="text-white/40">[outside]</span></div>
-            <div class="text-white font-bold mt-3 whitespace-nowrap">TENSIONS</div>
-            <div class="text-white/80 whitespace-nowrap">Binary size vs. escape hatch availability.</div>
-          </div>
-        </div>
-
-        <!-- Trace -->
-        <div id="trace">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost trace</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Reconstruct the causal chain of decisions that led to the current state of a file, symbol, or concept. Works across sessions, time, and messy work threads.</p>
-          <pre><code>unlost trace src/governor.rs
-unlost trace "why is the timeout 30s?"
-unlost trace proxy_request --since 3M</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example: unlost trace src/http_proxy.rs</div>
-            <div class="text-white/80 whitespace-nowrap">The proxy module was deprecated in favour of the plugin/companion</div>
-            <div class="text-white/80 whitespace-nowrap">architecture; `src/http_proxy.rs` now sits unreachable behind a</div>
-            <div class="text-white/80 whitespace-nowrap">hidden CLI flag.</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">• Early work used `record --upstream-host` to intercept OpenAI traffic</div>
-            <div class="text-white/60 whitespace-nowrap">• A retry spiral on `proxy_request` prompted the switch to plugin mode</div>
-            <div class="text-white/60 whitespace-nowrap">• `companion/flow.rs` replaced the proxy as the recording path</div>
-            <div class="text-white/60 whitespace-nowrap">• The CLI kept the flag hidden rather than removing it to avoid breakage</div>
-            <div class="text-white/40 mt-2 whitespace-nowrap">The key constraint: the plugin path owns recording; the proxy is legacy.</div>
-            <div class="text-cyan-400/70 mt-1 whitespace-nowrap">  unlost query "what replaced the proxy recording path?"</div>
-            <div class="text-white/40 mt-2 whitespace-nowrap">─── chain: 7 capsules | oldest: 2026-01-14T10:22:11Z | newest: 2026-02-09T15:12:32Z</div>
-          </div>
-        </div>
-
-        <!-- Monitor -->
-        <div id="metrics">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost metrics</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#00a483]/10 text-[#00a483] w-fit">Monitor</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Show workspace trajectory metrics and friction hotspots. <a href="#metrics-guide" class="text-fiery-terracotta hover:underline">See detailed guide</a>.</p>
-          <pre><code>unlost metrics</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Cognitive Mirror (v0.3.0)</div>
-            <div class="text-white/80 whitespace-nowrap">friction rate:  12.4 warnings / 1M tokens</div>
-            <div class="text-white/80 whitespace-nowrap">avg interval:   42,100 tokens</div>
-            <div class="text-white/80 whitespace-nowrap">avg verbosity:  14.2x (assistant/user)</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">=== Heuristic Signals ===</div>
-            <div class="text-white/80 whitespace-nowrap">loop: 12 | spec: 8 | drift: 4</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">=== Friction vs Context Size ===</div>
-            <div class="text-white/80 whitespace-nowrap">Bucket | Turns | Rate (Warnings/100 Turns)</div>
-            <div class="text-white/80 whitespace-nowrap">0-4k   | 45    | 2.2%</div>
-            <div class="text-white/80 whitespace-nowrap">8k-12k | 12    | 16.6% (Inflection)</div>
-          </div>
-        </div>
-
-        <div id="replay">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost replay</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#00a483]/10 text-[#00a483] w-fit">Monitor</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Replay and backfill agent transcripts to analyze past sessions. Use <code>--git-grounding</code> to verify agent claims against actual commits.</p>
-          <pre><code>unlost replay opencode --git-grounding --no-llm
-unlost replay claudecode --transcript-path history.json</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example: bulk backfill with git verification</div>
-            <div class="text-white/80 whitespace-nowrap">$ unlost replay opencode --git-grounding --no-llm</div>
-            <div class="text-white/80 whitespace-nowrap">✓ Replay complete: 2 sessions, 604 capsules recorded</div>
-          </div>
-        </div>
-
-        <div id="inspect">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost inspect</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#00a483]/10 text-[#00a483] w-fit">Monitor</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Inspect stored capsules for this workspace.</p>
-          <pre><code>unlost inspect</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example: first few capsules</div>
-            <div class="text-white/80 whitespace-nowrap">workspace: wks_83ae697ac0204117</div>
-            <div class="text-white/80 whitespace-nowrap">---</div>
-            <div class="text-white/80 whitespace-nowrap">chunked_at: 2026-02-13T19:27:34Z</div>
-            <div class="text-white/80 whitespace-nowrap">session: ses_3a7964f37ffeQTc62ugRjgTIB1</div>
-            <div class="text-white/80 whitespace-nowrap">conn: 15 seq: 1 status: 200</div>
-            <div class="text-white/80 whitespace-nowrap">user_mood: confused (conf=0.68 val=0.00 int=0.55)</div>
-            <div class="text-white/80 whitespace-nowrap">category: documentation</div>
-            <div class="text-white/80 whitespace-nowrap">intent: Update the gh-pages branch to publish the latest documentation</div>
-            <div class="text-white/80 whitespace-nowrap">decision: Proceed to update gh-pages with the latest built docs</div>
-            <div class="text-white/80 whitespace-nowrap">symbols: ["gh-pages", "docs/index.html"]</div>
-            <div class="text-white/80 whitespace-nowrap">---</div>
-            <div class="text-white/60 whitespace-nowrap">... (more capsules follow)</div>
-          </div>
-        </div>
-
-        <!-- Manage -->
-        <div id="reindex">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost reindex</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#9856ca]/10 text-[#9856ca] w-fit">Manage</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Rebuild LanceDB index from capsules.jsonl.</p>
-          <pre><code>unlost reindex</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example output</div>
-            <div class="text-white/80 whitespace-nowrap">Found 1758 capsules in /home/mcfly/.local/share/unlost/workspaces/</div>
-            <div class="text-white/80 whitespace-nowrap">wks_83ae697ac0204117/capsules.jsonl</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">Reindex will delete LanceDB and rebuild from JSONL. Continue? [y/N]</div>
-            <div class="text-white/80 whitespace-nowrap">Rebuilding index...</div>
-            <div class="text-white/80 whitespace-nowrap">✓ Indexed 1758 capsules in 2.34s</div>
-          </div>
-        </div>
-
-        <div id="clear">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost clear</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#9856ca]/10 text-[#9856ca] w-fit">Manage</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Delete all generated data for the current workspace.</p>
-          <pre><code>unlost clear</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example output</div>
-            <div class="text-white/80 whitespace-nowrap">This will delete ALL unlost data for workspace wks_83ae697ac0204117:</div>
-            <div class="text-white/80 whitespace-nowrap">- /home/mcfly/.local/share/unlost/workspaces/wks_83ae697ac0204117</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">Are you sure? Type 'yes' to confirm: yes</div>
-            <div class="text-white/80 mt-2 whitespace-nowrap">✓ Deleted 1138 capsules, LanceDB index, and metrics</div>
-            <div class="text-white/60 whitespace-nowrap">Workspace data cleared. Capsules will be rebuilt from journal on next run.</div>
-          </div>
-        </div>
-
-        <div id="where">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost where</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#9856ca]/10 text-[#9856ca] w-fit">Manage</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Show where the workspace's files are stored.</p>
-          <pre><code>unlost where</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example output</div>
-            <div class="text-white/80 whitespace-nowrap">Workspace ID: wks_83ae697ac0204117</div>
-            <div class="text-white/80 whitespace-nowrap">Source: git</div>
-            <div class="text-white/80 whitespace-nowrap">Root: /home/mcfly/my-project</div>
-            <div class="text-white/80 whitespace-nowrap">Storage: /home/mcfly/.local/share/unlost/workspaces/wks_83ae697ac0204117</div>
-          </div>
-        </div>
-
-        <div id="config">
-          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
-            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost config</h3>
-            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#9856ca]/10 text-[#9856ca] w-fit">Manage</span>
-          </div>
-          <p class="text-midnight-violet-950/60 mb-4">Manage configuration (LLM provider, agent integrations, etc.).</p>
-          <pre><code>unlost config
-unlost config agent claudecode --global
-unlost config agent opencode --path .
-unlost config llm anthropic --model claude-3-5-sonnet-20241022</code></pre>
-          <div class="terminal mt-4 overflow-x-auto">
-            <div class="text-white/40 mb-1"># unlost config (shows help)</div>
-            <div class="text-white/80 whitespace-nowrap">Manage configuration (LLM provider, etc.)</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">Usage: unlost config [OPTIONS] <COMMAND></div>
-            <div class="text-white/80 mt-2 whitespace-nowrap">Commands:</div>
-            <div class="text-white/80 whitespace-nowrap">  llm    Manage LLM configuration for init/query narratives</div>
-            <div class="text-white/80 whitespace-nowrap">  agent  Configure an agent workspace to talk to unlost</div>
-            <div class="text-white/80 whitespace-nowrap">  help   Print this message or the help of the given subcommand(s)</div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- How It Works -->
-  <section id="solution" class="section">
+  <!-- How It Works (Revised) -->
+  <section id="how-it-works" class="section">
     <div class="container-narrow">
       <h2 class="text-2xl sm:text-3xl font-medium mb-8 sm:mb-12 flex items-baseline flex-wrap gap-2">
         How It Works 
@@ -581,14 +252,19 @@ unlost config llm anthropic --model claude-3-5-sonnet-20241022</code></pre>
                <div class="text-4xl sm:text-6xl font-light text-midnight-violet-950/10 font-['Lexend']">01</div>
             </div>
             <div class="sm:col-span-10">
-              <h3 class="text-lg sm:text-xl font-semibold mb-3">Intercept & Sense</h3>
+              <h3 class="text-lg sm:text-xl font-semibold mb-3">Record</h3>
               <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-                Hooks into agent events in real-time. It monitors leading indicators: 
-                symbol repetition, novelty collapse, logic churn, and grounding failure.
+                Unlost sits alongside your agent process. It captures the raw stream of 
+                thought—intent, reasoning, and decisions—without blocking your flow.
               </p>
+              <div class="mb-6">
+                <a href="#silent-observer" class="text-xs font-medium text-fiery-terracotta hover:underline inline-flex items-center gap-1 group">
+                  See how we capture without blocking <span class="group-hover:translate-x-0.5 transition-transform">→</span>
+                </a>
+              </div>
               <div class="terminal">
-                <div class="text-white/40 mb-1"># Symptom channels (local)</div>
-                <div class="text-white/80">loop: 0.82 | spec: 0.15 | drift: 0.05</div>
+                <div class="text-white/40 mb-1"># Silent observation</div>
+                <div class="text-white/80">Recording session ses_3a79... [active]</div>
               </div>
             </div>
           </div>
@@ -599,15 +275,20 @@ unlost config llm anthropic --model claude-3-5-sonnet-20241022</code></pre>
                <div class="text-4xl sm:text-6xl font-light text-midnight-violet-950/10 font-['Lexend']">02</div>
             </div>
             <div class="sm:col-span-10">
-              <h3 class="text-lg sm:text-xl font-semibold mb-3">Model Trajectory</h3>
+              <h3 class="text-lg sm:text-xl font-semibold mb-3">Extract & Structure</h3>
               <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-                We model collaboration across three basins: <strong>Loop</strong> (stalls), 
-                <strong>Spec</strong> (misunderstanding), and <strong>Drift</strong> (hallucination). 
-                The controller moves from Stable → Watch → Intervene.
+                We don't just log text. Unlost distills messy conversations into 
+                <strong>Capsules</strong>: atomic units of memory containing the 
+                <em>Why</em>, the <em>What</em>, and the <em>How</em>.
               </p>
+              <div class="mb-6">
+                <a href="#long-memory" class="text-xs font-medium text-fiery-terracotta hover:underline inline-flex items-center gap-1 group">
+                  See how the causal chain is built <span class="group-hover:translate-x-0.5 transition-transform">→</span>
+                </a>
+              </div>
               <div class="terminal">
-                <div class="text-white/40 mb-1"># Controller state</div>
-                <div class="text-yellow-400">STATE: Watch | Intensity: 0.65 | Persistence: 2/3</div>
+                <div class="text-white/40 mb-1"># Extracted Capsule</div>
+                <div class="text-white/80">{intent: "Refactor auth", decision: "Use PASETO tokens", rationale: "..."}</div>
               </div>
             </div>
           </div>
@@ -618,341 +299,75 @@ unlost config llm anthropic --model claude-3-5-sonnet-20241022</code></pre>
                <div class="text-4xl sm:text-6xl font-light text-midnight-violet-950/10 font-['Lexend']">03</div>
             </div>
             <div class="sm:col-span-10">
-              <h3 class="text-lg sm:text-xl font-semibold mb-3">Proactive Regulation</h3>
+              <h3 class="text-lg sm:text-xl font-semibold mb-3">Ground</h3>
               <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-                When intensity crosses the intervention threshold, Unlost injects guidance 
-                directly into the conversation. It forces factual grounding or planning 
-                before the agent proceeds.
+                Every capsule is verified against the live code graph. We link decisions 
+                to specific files and symbols, creating a navigable map of your project's evolution.
               </p>
+              <div class="mb-6">
+                 <a href="#code-graph" class="text-xs font-medium text-fiery-terracotta hover:underline inline-flex items-center gap-1 group">
+                    See how we build the map <span class="group-hover:translate-x-0.5 transition-transform">→</span>
+                 </a>
+              </div>
               <div class="terminal">
-                <div class="text-fiery-terracotta">Intervention Triggered (Spec Basin)</div>
-                <div class="text-white/80">[SYSTEM: You've repeated this instruction 3 times. Verify current symbols.]</div>
+                <div class="text-white/40 mb-1"># Graph Links</div>
+                <div class="text-white/80">Linked: src/auth.rs (80% relevance) | Symbol: verify_token</div>
               </div>
             </div>
           </div>
   
-          <!-- Step 4 -->
-          <div id="step-04" class="flex flex-col sm:grid sm:grid-cols-12 gap-4 sm:gap-8 items-start">
-            <div class="sm:col-span-2">
-               <div class="text-4xl sm:text-6xl font-light text-midnight-violet-950/10 font-['Lexend']">04</div>
-            </div>
-            <div class="sm:col-span-10">
-              <h3 class="text-lg sm:text-xl font-semibold mb-3">Extract & Localize</h3>
-              <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-                Summarizes the exchange into a queryable "Capsule" (intent, decision, symbols). 
-                All embeddings and storage stay local in LanceDB for private, fast recall.
-              </p>
-              <div class="terminal">
-                <div class="text-white/40 mb-1"># Local Memory</div>
-                <div class="text-white/80">{decision: "Retain raw text for search", symbols: ["src/storage.rs"]}</div>
-              </div>
-            </div>
-          </div>
-  
-          <!-- Step 5 -->
-          <div id="step-05" class="flex flex-col sm:grid sm:grid-cols-12 gap-4 sm:gap-8 items-start">
-            <div class="sm:col-span-2">
-               <div class="text-4xl sm:text-6xl font-light text-midnight-violet-950/10 font-['Lexend']">05</div>
-            </div>
-            <div class="sm:col-span-10">
-              <h3 class="text-lg sm:text-xl font-semibold mb-3">Cognitive Mirror (Metrics)</h3>
-              <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-                Unlost tracks your "friction rate" vs context size. It identifies codebase hotspots 
-                and context thresholds where collaboration begins to break down.
-              </p>
-              <div class="terminal">
-                <div class="text-white/40 mb-1"># Metrics insight</div>
-                <div class="text-white/80">Inflection detected at 12k tokens (Rate: 15 warnings / 100 turns)</div>
-              </div>
-            </div>
-          </div>
+          <!-- One Memory. Many Lenses. -->
+          <div class="pt-8 sm:pt-12 mt-8 sm:mt-12 border-t border-midnight-violet-950/5">
+             <h3 class="text-2xl sm:text-3xl font-medium mb-8 flex items-baseline flex-wrap gap-2">
+                One Memory. Many Lenses.
+                <span class="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-fiery-terracotta mt-1"></span>
+              </h3>
+             <p class="text-midnight-violet-950/60 leading-relaxed mb-10">
+                Once context is grounded, you can query it from any angle.
+             </p>
+             <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                <!-- Look Back -->
+                <div>
+                   <h4 class="text-lg font-semibold text-fiery-terracotta mb-3">Look Back</h4>
+                   <p class="text-sm text-midnight-violet-950/60 leading-relaxed mb-3">
+                      Recover the context you lost. Whether it's a high-level staff engineer debrief or a specific decision trail, you get the <em>why</em> behind the code.
+                   </p>
+                   <div class="flex gap-2 text-xs font-mono text-midnight-violet-950/40">
+                      <span class="bg-midnight-violet-950/5 px-2 py-1 rounded">trace</span>
+                      <span class="bg-midnight-violet-950/5 px-2 py-1 rounded">brief</span>
+                   </div>
+                </div>
 
-        </div>
-      </div>
-    </div>
-  </section>
+                <!-- Challenge Present -->
+                <div>
+                   <h4 class="text-lg font-semibold text-fiery-terracotta mb-3">Challenge Present</h4>
+                   <p class="text-sm text-midnight-violet-950/60 leading-relaxed mb-3">
+                      Don't just approve; verify. Pressure-test decisions against the graph and monitor the agent's struggle in real-time.
+                   </p>
+                   <div class="flex gap-2 text-xs font-mono text-midnight-violet-950/40">
+                      <span class="bg-midnight-violet-950/5 px-2 py-1 rounded">challenge</span>
+                      <span class="bg-midnight-violet-950/5 px-2 py-1 rounded">metrics</span>
+                   </div>
+                </div>
 
-  <!-- Components of Unlost -->
-  <section id="components" class="section">
-    <div class="container-narrow">
-      <h2 class="text-2xl sm:text-3xl font-medium mb-8 sm:mb-12 flex items-baseline flex-wrap gap-2">
-        The Components of Unlost 
-        <span class="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-fiery-terracotta mt-1"></span>
-      </h2>
-
-      <div class="space-y-12 sm:space-y-16">
-        <!-- Capsule Memory -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-4">Capsule Memory</h3>
-          <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-            Structured, searchable records of agent conversations. Each capsule captures intent, decisions, rationale, and next steps, building a persistent memory layer for your codebase.
-          </p>
-          <div class="terminal overflow-x-auto">
-            <div class="text-white/40 mb-1"># Example capsule</div>
-            <div class="text-white/80 whitespace-nowrap">chunked_at: 2026-02-13T14:47:31Z</div>
-            <div class="text-white/80 whitespace-nowrap">session: ses_3a887ec6effeHddMqe9691wY6V</div>
-            <div class="text-white/80 whitespace-nowrap">conn: 5 seq: 1 status: 200</div>
-            <div class="text-white/80 whitespace-nowrap">category: repo_exploration</div>
-            <div class="text-white/80 whitespace-nowrap">intent: Thoroughly explore the codebase to learn what Unlost does...</div>
-            <div class="text-white/80 whitespace-nowrap">decision: Proceed to review README, main configuration files...</div>
-            <div class="text-white/80 whitespace-nowrap">rationale: The user explicitly requested a deep codebase review...</div>
-            <div class="text-white/80 whitespace-nowrap">next: ["Open README and main configuration files...", ...]</div>
-            <div class="text-white/80 whitespace-nowrap">symbols: ["README", "Claude"]</div>
-          </div>
-        </div>
-
-        <!-- Facts & Metadata -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-4">Facts and Metadata We Store</h3>
-          <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-            Beyond raw text, we extract and index key entities that enable precise semantic search and context-aware recall:
-          </p>
-          <ul class="list-disc pl-4 sm:pl-5 space-y-2 text-midnight-violet-950/60 mb-4">
-            <li><strong>Symbols:</strong> Functions, classes, variables, and code identifiers mentioned in conversations</li>
-            <li><strong>Files:</strong> File paths and references to help locate where changes occurred</li>
-            <li><strong>Technologies:</strong> Frameworks, libraries, and tools being used or discussed</li>
-            <li><strong>People:</strong> User mentions and agent identities for accountability tracking</li>
-            <li><strong>Relationships:</strong> Links between entities (e.g., which function belongs to which file)</li>
-            <li><strong>Session context:</strong> Connection IDs, sequence numbers, and temporal metadata</li>
-          </ul>
-          <p class="text-midnight-violet-950/60 leading-relaxed">
-            Unlost uses this metadata to build a knowledge graph that powers targeted queries. When you search for "auth flow", we don't just match text: we understand which files and symbols are involved, enabling you to ask precise questions like "what changed in the auth middleware last week?"
-          </p>
-        </div>
-
-        <!-- Emotions -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-4">Emotions</h3>
-          <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-            We analyze conversation patterns to detect emotional signals that indicate when interactions may be deteriorating:
-          </p>
-          <ul class="list-disc pl-4 sm:pl-5 space-y-2 text-midnight-violet-950/60 mb-4">
-            <li><strong>Valence:</strong> Positive vs negative sentiment (-1.0 to +1.0)</li>
-            <li><strong>Intensity:</strong> Strength of the emotional response (0.0 to 1.0)</li>
-            <li><strong>Confidence:</strong> Certainty in the emotional classification (0.0 to 1.0)</li>
-          </ul>
-          <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-            The purpose is early detection of friction before it escalates. When emotion signals cross thresholds, Unlost can intervene with guidance or escalate to the user.
-          </p>
-          <div class="terminal overflow-x-auto">
-            <div class="text-white/40 mb-1"># Emotion detection example</div>
-            <div class="text-white/80 whitespace-nowrap">user_mood: frustration (conf=0.55 val=-0.50 int=0.45)</div>
-            <div class="text-white/40 mt-2"># Detected from patterns like:</div>
-            <div class="text-white/60">- "That didn't work" followed by multiple retries</div>
-            <div class="text-white/60">- Increased negative language density</div>
-            <div class="text-white/60">- Repeated similar prompts with escalating tone</div>
-          </div>
-        </div>
-
-        <!-- The Three Basins of Friction -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-4">The Three Basins of Friction</h3>
-          <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-            Unlost models interaction dynamics across three distinct "Basins of Friction" to provide proactive regulation:
-          </p>
-          <div class="space-y-6 text-midnight-violet-950/60 mb-6">
-            <div>
-              <h4 class="font-semibold text-midnight-violet-950 mb-1">Loop Basin (The Stall)</h4>
-              <p>Detects repetitive failures, symbol stalls, and logic churn. Triggered by high EMA-smoothed repetition and low novelty.</p>
-            </div>
-            <div>
-              <h4 class="font-semibold text-midnight-violet-950 mb-1">Spec Basin (Misunderstanding)</h4>
-              <p>Detects alignment debt (user corrections) and instruction staticness (verbatim repeats). Triggered by persistent alignment failures.</p>
-            </div>
-            <div>
-              <h4 class="font-semibold text-midnight-violet-950 mb-1">Drift Basin (Grounding Failure)</h4>
-              <p>Detects grounding stalls (ignoring user file mentions) and symbol hallucinations. Validated against a live codebase graph via <a href="https://github.com/unfault/core" class="text-fiery-terracotta hover:underline font-mono text-sm">unfault-core</a>.</p>
-            </div>
-          </div>
-          <div class="terminal overflow-x-auto">
-            <div class="text-white/40 mb-1"># Proactive Intervention Example</div>
-            <div class="text-white/80 whitespace-nowrap">Basin: Drift | Intensity: 0.95 | persistence: 3/3</div>
-            <div class="text-white/80 whitespace-nowrap">Cause: Agent hallucinated `AuthValidator` symbol (missing in src/)</div>
-            <div class="text-fiery-terracotta whitespace-nowrap">Action: Inject Hard Reset requiring 3 verified facts.</div>
-          </div>
-        </div>
-
-        <!-- Memory Commands -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-4">Memory Commands</h3>
-          <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
-            Five purpose-built commands that answer different questions about your workspace memory. Each one frames its retrieval query to match the kind of questions stored at indexing time (HyPE), so you get higher-precision results with no extra LLM cost.
-          </p>
-          
-          <div class="space-y-6 text-midnight-violet-950/60">
-            <div>
-              <h4 class="font-semibold text-midnight-violet-950 mb-1 text-sm sm:text-base"><code>recall</code> - what happened?</h4>
-              <p class="leading-relaxed">Narrates the recent story for a file, symbol, or concept. Recency-weighted, low-signal capsules filtered out. Query framed as <em>"What happened with X?"</em></p>
-            </div>
-            <div>
-              <h4 class="font-semibold text-midnight-violet-950 mb-1 text-sm sm:text-base"><code>brief</code> - why is it this way?</h4>
-              <p class="leading-relaxed">Staff-engineer debrief across all recorded history. Scores by importance (failure modes, rationale, recurrence), not recency. Query framed as <em>"Why is the current state of X the way it is?"</em></p>
-            </div>
-            <div>
-              <h4 class="font-semibold text-midnight-violet-950 mb-1 text-sm sm:text-base"><code>trace</code> - how did we get here?</h4>
-              <p class="leading-relaxed">Causal chain: seed via ANN, fan out by shared symbols, sort chronologically. Query framed as <em>"What sequence of decisions led to X?"</em></p>
-            </div>
-            <div>
-              <h4 class="font-semibold text-midnight-violet-950 mb-1 text-sm sm:text-base"><code>challenge</code> - should we have?</h4>
-              <p class="leading-relaxed">Pressure-tests a past decision against memory + live code graph. Query framed as <em>"Was the decision about X the right call?"</em></p>
-            </div>
-            <div>
-              <h4 class="font-semibold text-midnight-violet-950 mb-1 text-sm sm:text-base"><code>explore</code> - what could we do?</h4>
-              <p class="leading-relaxed">Forward-looking planning, labels memory vs. outside knowledge. Query framed as <em>"What are the alternatives and trade-offs for X?"</em></p>
-            </div>
-          </div>
-          
-          <div class="terminal mt-6 overflow-x-auto">
-            <div class="text-white/40 mb-1"># HyPE framing in action (no LLM call, just string + embed)</div>
-            <div class="text-white/60 whitespace-nowrap">unlost recall src/auth.rs</div>
-            <div class="text-white/40 whitespace-nowrap">  → embeds: "What happened with src/auth.rs?"</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">unlost challenge "lancedb"</div>
-            <div class="text-white/40 whitespace-nowrap">  → embeds: "Was the decision about lancedb the right call?"</div>
-            <div class="text-white/60 mt-2 whitespace-nowrap">unlost explore "federation"</div>
-            <div class="text-white/40 whitespace-nowrap">  → embeds: "What are the alternatives and trade-offs for federation?"</div>
+                <!-- Explore Future -->
+                <div>
+                   <h4 class="text-lg font-semibold text-fiery-terracotta mb-3">Explore Future</h4>
+                   <p class="text-sm text-midnight-violet-950/60 leading-relaxed mb-3">
+                      Draft with memory. Use your established constraints and history to weigh new trade-offs before writing a single line of code.
+                   </p>
+                   <div class="flex gap-2 text-xs font-mono text-midnight-violet-950/40">
+                      <span class="bg-midnight-violet-950/5 px-2 py-1 rounded">explore</span>
+                   </div>
+                </div>
+             </div>
           </div>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Metrics Guide -->
-  <section id="metrics-guide" class="section">
-    <div class="container-narrow">
-      <h2 class="text-2xl sm:text-3xl font-medium mb-8 sm:mb-12 flex items-baseline flex-wrap gap-2">
-        Interpreting the Cognitive Mirror 
-        <span class="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-fiery-terracotta mt-1"></span>
-      </h2>
-
-      <p class="text-lg sm:text-xl text-midnight-violet-950/60 mb-12 leading-relaxed">
-        The <code>unlost metrics</code> command generates a <strong>Cognitive Mirror</strong>: a diagnostic 
-        report that reveals the structural health of your collaboration with AI agents.
-      </p>
-
-      <div class="space-y-16">
-        <!-- At a Glance -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-6 uppercase tracking-wider text-sm">At a Glance</h3>
-          <div class="grid grid-cols-1 gap-8">
-            <div>
-              <div class="font-mono text-xs text-fiery-terracotta mb-2">friction rate</div>
-              <p class="text-midnight-violet-950/60 leading-relaxed">
-                Measured in <strong>warnings per 1M tokens</strong>. This is your primary "Babysitting Tax" indicator. 
-                A rate under 5 is healthy exploration; over 10 indicates a session that is likely 
-                stalling or drifting.
-              </p>
-            </div>
-            <div>
-              <div class="font-mono text-xs text-fiery-terracotta mb-2">avg interval</div>
-              <p class="text-midnight-violet-950/60 leading-relaxed">
-                The average number of tokens processed between proactive interventions. Short intervals 
-                suggest you are fighting the agent's mental model turn-by-turn.
-              </p>
-            </div>
-            <div>
-              <div class="font-mono text-xs text-fiery-terracotta mb-2">avg verbosity</div>
-              <p class="text-midnight-violet-950/60 leading-relaxed">
-                The ratio of assistant tokens to user tokens. If this hits <strong>14x</strong> or higher, 
-                you have transitioned from Architect to Passive Observer, the "Blind Acceptance" zone.
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <!-- Failure Modes -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-6 uppercase tracking-wider text-sm">Failure Modes (LLM-detected)</h3>
-          <p class="text-midnight-violet-950/60 leading-relaxed mb-6">
-            These represent the agent's own retrospective analysis of where it failed, categorized during capsule extraction:
-          </p>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-12 gap-y-6 text-sm">
-            <div>
-              <div class="font-bold mb-1">Retry Spiral</div>
-              <p class="text-midnight-violet-950/60">Agent is stuck in a loop, repeatedly attempting the same failing approach.</p>
-            </div>
-            <div>
-              <div class="font-bold mb-1">Factual Drift</div>
-              <p class="text-midnight-violet-950/60">Agent is operating on a wrong mental model of the codebase structure.</p>
-            </div>
-            <div>
-              <div class="font-bold mb-1">Spec Debt</div>
-              <p class="text-midnight-violet-950/60">Misunderstanding user instructions or ignoring established constraints.</p>
-            </div>
-            <div>
-              <div class="font-bold mb-1">False Progress</div>
-              <p class="text-midnight-violet-950/60">Agent claims completion while the underlying issue remains unresolved.</p>
-            </div>
-          </div>
-        </div>
-
-        <!-- Context Inflection -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-6 uppercase tracking-wider text-sm">Friction vs Context Size</h3>
-          <p class="text-midnight-violet-950/60 leading-relaxed mb-6">
-            Unlost buckets friction by input token count to identify your agent's <strong>Context Inflection Point</strong>.
-          </p>
-          <div class="bg-midnight-violet-950/5 p-6 rounded-2xl border border-midnight-violet-950/5">
-            <p class="text-sm italic text-midnight-violet-950/70 mb-4 leading-relaxed">
-              "For most current models, we observe a stability collapse between 8k and 12k tokens. 
-              The friction rate typically doubles past this point as the 'lost in the middle' phenomenon 
-              degrades grounding."
-            </p>
-            <div class="text-[10px] font-mono uppercase tracking-widest text-midnight-violet-950/30 text-center">Typical Inflection Pattern</div>
-          </div>
-        </div>
-
-        <!-- Trigger Drivers -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-6 uppercase tracking-wider text-sm">Trigger Drivers (Symptom Breakdown)</h3>
-          <p class="text-midnight-violet-950/60 leading-relaxed mb-6">
-            This section reveals the underlying "physics" that triggered proactive interventions:
-          </p>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-8 text-sm">
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-bold mb-1">Alignment (Spec Basin)</div>
-              <p class="text-midnight-violet-950/60">Driven by instruction repetition and verbatim corrective keywords.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-bold mb-1">Stall (Loop Basin)</div>
-              <p class="text-midnight-violet-950/60">Driven by symbol repetition and novelty collapse across turns.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-bold mb-1">Hallucination (Drift Basin)</div>
-              <p class="text-midnight-violet-950/60">Driven by non-existent paths or identifiers mentioned by the agent.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-bold mb-1">Effort Spike</div>
-              <p class="text-midnight-violet-950/60">Driven by sudden increases in turn complexity or symbol density.</p>
-            </div>
-          </div>
-        </div>
-
-        <!-- Hotspots -->
-        <div>
-          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-6 uppercase tracking-wider text-sm">Identifying Hotspots</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-12">
-            <div>
-              <div class="font-bold mb-2">Top Friction Files</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">
-                Lists the specific source files where most proactive warnings were triggered. This 
-                identifies areas of your codebase that are currently "unstable" for AI reasoning.
-              </p>
-            </div>
-            <div>
-              <div class="font-bold mb-2">High-Cost Windows</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">
-                Identifies interventions that were followed by the most expensive subsequent turns. 
-                This helps you find the specific moments where a failure spiral burned the most 
-                budget and time.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Long Memory Story Arc -->
+  <!-- Long Memory Story Arc (Moved Up) -->
   <section id="long-memory" class="section border-t border-midnight-violet-950/5">
     <div class="container-narrow">
       <h2 class="text-2xl sm:text-3xl font-medium mb-4 flex items-baseline flex-wrap gap-2">
@@ -1022,33 +437,277 @@ unlost config llm anthropic --model claude-3-5-sonnet-20241022</code></pre>
             <div class="text-white/80 whitespace-nowrap">2026-02-18  [ses_b] <span class="text-fiery-terracotta">← you are here</span></div>
           </div>
         </div>
+      </div>
+    </div>
+  </section>
 
-        <!-- The commands -->
+  <!-- Install -->
+  <section id="install" class="section">
+    <div class="container-narrow">
+      <h2 class="text-2xl sm:text-3xl font-medium mb-8 sm:mb-12 flex items-baseline flex-wrap gap-2">
+        Install 
+        <span class="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-fiery-terracotta mt-1"></span>
+      </h2>
+
+      <div class="space-y-8">
         <div>
-          <h3 class="text-base sm:text-lg font-semibold mb-4">The commands</h3>
-          <div class="space-y-6 text-sm text-midnight-violet-950/60">
+          <h3 class="text-base sm:text-lg font-semibold mb-4">Get Unlost</h3>
+          <pre class="text-xs sm:text-sm"><code>curl -fsSL https://unlost.unfault.dev/install.sh | bash</code></pre>
+          <small class="text-midnight-violet-950/60 block mt-2 text-sm">For Windows, please download the binary from our <a href="https://github.com/unfault/unlost/releases" class="text-fiery-terracotta hover:underline">releases</a> page.</small>
+        </div>
+
+        <div>
+          <h3 class="text-base sm:text-lg font-semibold mb-4">Agent Integration</h3>
+          <p class="text-midnight-violet-950/60 mb-4">
+            Hook unlost into your agent. This installs the Unlost agent skill (for OpenCode) and configures the necessary hooks.
+          </p>
+          <pre><code># Claude Code - one command, works everywhere
+unlost config agent claudecode --global
+
+# OpenCode - opt-in per repository
+cd your-project
+unlost config agent opencode --path .</code></pre>
+        </div>
+
+        <div>
+          <h3 class="text-base sm:text-lg font-semibold mb-4">Configure Your LLM</h3>
+          <p class="text-midnight-violet-950/60 mb-4">
+            Unlost requires an LLM for capsule extraction and summarization. 
+          </p>
+          <pre><code>unlost config llm anthropic --model claude-sonnet-4-5-20250929
+unlost config llm openai --model gpt-4o-mini</code></pre>
+          <small class="text-midnight-violet-950/60 block mt-2 text-sm">
+            <strong>Recommendation:</strong> Use a fast, cheap model like GPT-4o-mini or Claude 3.5 Haiku. 
+          </small>
+        </div>
+
+        <div class="pl-3 sm:pl-4 border-l-4 border-fiery-terracotta">
+          <p class="text-midnight-violet-950/70">
+            That's it. Next time you start your agent, unlost will automatically work alongside it.
+            <span class="text-midnight-violet-950/50">Happy coding!</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Commands -->
+  <section id="commands" class="section">
+    <div class="container-narrow">
+      <h2 class="text-2xl sm:text-3xl font-medium mb-8 sm:mb-12 flex items-baseline flex-wrap gap-2">
+        Commands 
+        <span class="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-fiery-terracotta mt-1"></span>
+      </h2>
+
+      <div class="space-y-10 sm:space-y-12">
+        <!-- Brief -->
+        <div id="brief">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost brief</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">A staff engineer's debrief on any codebase: what matters, what bites, where to start. Scans all recorded memory (conversations + git commits) and scores by importance, not recency.</p>
+          <pre><code>unlost brief
+unlost brief src/governor.rs
+unlost brief TrajectoryController</code></pre>
+        </div>
+
+        <!-- Recall -->
+        <div id="recall">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost recall</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Recall the story so far (proactive overview) from a specific file or directory.</p>
+          <pre><code>unlost recall src/http_proxy.rs
+unlost recall src/</code></pre>
+        </div>
+
+        <!-- Trace -->
+        <div id="trace">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost trace</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Reconstruct the causal chain of decisions that led to the current state of a file, symbol, or concept.</p>
+          <pre><code>unlost trace src/governor.rs
+unlost trace "why is the timeout 30s?"</code></pre>
+        </div>
+
+        <div id="challenge">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost challenge</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Pressure-test a past decision or technology choice using workspace memory and the live code graph.</p>
+          <pre><code>unlost challenge "lancedb"</code></pre>
+        </div>
+
+        <div id="explore">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost explore</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#bd51ea]/10 text-[#bd51ea] w-fit">Memory</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Explore future paths grounded in your workspace memory.</p>
+          <pre><code>unlost explore "should we keep lancedb or move to sqlite+fts?"</code></pre>
+        </div>
+
+        <!-- Monitor -->
+        <div id="metrics">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost metrics</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#00a483]/10 text-[#00a483] w-fit">Monitor</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Show workspace trajectory metrics and friction hotspots.</p>
+          <pre><code>unlost metrics</code></pre>
+        </div>
+
+        <div id="replay">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost replay</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#00a483]/10 text-[#00a483] w-fit">Monitor</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Replay and backfill agent transcripts.</p>
+          <pre><code>unlost replay opencode --git-grounding --no-llm</code></pre>
+        </div>
+
+        <div id="inspect">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost inspect</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#00a483]/10 text-[#00a483] w-fit">Monitor</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Inspect stored capsules for this workspace.</p>
+          <pre><code>unlost inspect</code></pre>
+        </div>
+
+        <!-- Manage -->
+        <div id="reindex">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost reindex</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#9856ca]/10 text-[#9856ca] w-fit">Manage</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Rebuild LanceDB index from capsules.jsonl.</p>
+          <pre><code>unlost reindex</code></pre>
+        </div>
+
+        <div id="clear">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost clear</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#9856ca]/10 text-[#9856ca] w-fit">Manage</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Delete all generated data for the current workspace.</p>
+          <pre><code>unlost clear</code></pre>
+        </div>
+
+        <div id="where">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost where</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#9856ca]/10 text-[#9856ca] w-fit">Manage</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Show where the workspace's files are stored.</p>
+          <pre><code>unlost where</code></pre>
+        </div>
+
+        <div id="config">
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline mb-3 gap-2">
+            <h3 class="text-base sm:text-lg font-semibold text-fiery-terracotta">unlost config</h3>
+            <span class="px-3 py-1 text-xs font-medium rounded-full bg-[#9856ca]/10 text-[#9856ca] w-fit">Manage</span>
+          </div>
+          <p class="text-midnight-violet-950/60 mb-4">Manage configuration (LLM provider, agent integrations, etc.).</p>
+          <pre><code>unlost config</code></pre>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Cognitive Mirror (Metrics & Models) -->
+  <section id="cognitive-mirror" class="section border-t border-midnight-violet-950/5">
+    <div class="container-narrow">
+      <h2 class="text-2xl sm:text-3xl font-medium mb-8 sm:mb-12 flex items-baseline flex-wrap gap-2">
+        The Cognitive Mirror 
+        <span class="inline-block w-4 h-4 sm:w-5 sm:h-5 rounded-full bg-fiery-terracotta mt-1"></span>
+      </h2>
+
+      <p class="text-lg sm:text-xl text-midnight-violet-950/60 mb-12 leading-relaxed">
+        The <code>unlost metrics</code> command generates a <strong>Cognitive Mirror</strong>: a diagnostic 
+        report that reveals the structural health of your collaboration with AI agents.
+      </p>
+
+      <div class="space-y-16">
+        <!-- Emotions -->
+        <div>
+          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-4">Emotional Dynamics</h3>
+          <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
+            We analyze conversation patterns to detect emotional signals that indicate when interactions may be deteriorating:
+          </p>
+          <ul class="list-disc pl-4 sm:pl-5 space-y-2 text-midnight-violet-950/60 mb-4">
+            <li><strong>Valence:</strong> Positive vs negative sentiment (-1.0 to +1.0)</li>
+            <li><strong>Intensity:</strong> Strength of the emotional response (0.0 to 1.0)</li>
+          </ul>
+          <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
+            The purpose is early detection of friction before it escalates. When emotion signals cross thresholds, Unlost can intervene with guidance.
+          </p>
+        </div>
+
+        <!-- The Three Basins of Friction -->
+        <div>
+          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-4">The Three Basins of Friction</h3>
+          <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
+            Unlost models interaction dynamics across three distinct "Basins of Friction" to provide proactive regulation:
+          </p>
+          <div class="space-y-6 text-midnight-violet-950/60 mb-6">
             <div>
-              <code class="text-fiery-terracotta text-base">unlost trace &lt;target&gt;</code>
-              <p class="mt-2 leading-relaxed">The primary long-memory command. Pass a file, a symbol, or a natural-language question. Unlost builds the causal chain and hands it to the LLM to narrate the path: key turning points, recorded failures, the constraint that explains the current state.</p>
+              <h4 class="font-semibold text-midnight-violet-950 mb-1">Loop Basin (The Stall)</h4>
+              <p>Detects repetitive failures, symbol stalls, and logic churn. Triggered by high EMA-smoothed repetition and low novelty.</p>
             </div>
             <div>
-              <code class="text-fiery-terracotta text-base">unlost trace "..." --since 4M --until 3M</code>
-              <p class="mt-2 leading-relaxed">For incident investigation: constrain the chain to a specific time window. <em>"What happened three months ago that might have contributed to this bug?"</em></p>
+              <h4 class="font-semibold text-midnight-violet-950 mb-1">Spec Basin (Misunderstanding)</h4>
+              <p>Detects alignment debt (user corrections) and instruction staticness (verbatim repeats).</p>
             </div>
             <div>
-              <code class="text-fiery-terracotta text-base">unlost brief src/governor.rs</code>
-              <p class="mt-2 leading-relaxed">Brief uses the code graph to automatically expand the scope to related files (dependencies and dependents) before fetching capsules. The LLM receives a system map alongside the capsules, so it can explain the <em>system</em> rather than just the file.</p>
+              <h4 class="font-semibold text-midnight-violet-950 mb-1">Drift Basin (Grounding Failure)</h4>
+              <p>Detects grounding stalls (ignoring user file mentions) and symbol hallucinations. Validated against a live codebase graph via <a href="https://github.com/unfault/core" class="text-fiery-terracotta hover:underline font-mono text-sm">unfault-core</a>.</p>
             </div>
           </div>
         </div>
 
-        <!-- Reindex note -->
-        <div class="pl-4 border-l-2 border-fiery-terracotta/30">
-          <p class="text-sm text-midnight-violet-950/50 leading-relaxed">
-            <strong class="text-midnight-violet-950/70">Already have capsules?</strong> New capsules automatically get richer embeddings and HyPE questions. To apply these improvements to your existing capsule history, run <code>unlost reindex</code> - it rebuilds the LanceDB index from your stored capsules.
-          </p>
+        <!-- At a Glance -->
+        <div>
+          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-6 uppercase tracking-wider text-sm">Metrics at a Glance</h3>
+          <div class="grid grid-cols-1 gap-8">
+            <div>
+              <div class="font-mono text-xs text-fiery-terracotta mb-2">friction rate</div>
+              <p class="text-midnight-violet-950/60 leading-relaxed">
+                Measured in <strong>warnings per 1M tokens</strong>. This is your primary "Babysitting Tax" indicator. 
+                A rate under 5 is healthy exploration; over 10 indicates a session that is likely 
+                stalling or drifting.
+              </p>
+            </div>
+            <div>
+              <div class="font-mono text-xs text-fiery-terracotta mb-2">avg interval</div>
+              <p class="text-midnight-violet-950/60 leading-relaxed">
+                The average number of tokens processed between proactive interventions. Short intervals 
+                suggest you are fighting the agent's mental model turn-by-turn.
+              </p>
+            </div>
+          </div>
         </div>
 
+        <!-- Context Inflection -->
+        <div>
+          <h3 class="text-lg sm:text-xl font-semibold text-fiery-terracotta mb-6 uppercase tracking-wider text-sm">Friction vs Context Size</h3>
+          <p class="text-midnight-violet-950/60 leading-relaxed mb-6">
+            Unlost buckets friction by input token count to identify your agent's <strong>Context Inflection Point</strong>.
+          </p>
+          <div class="bg-midnight-violet-950/5 p-6 rounded-2xl border border-midnight-violet-950/5">
+            <p class="text-sm italic text-midnight-violet-950/70 mb-4 leading-relaxed">
+              "For most current models, we observe a stability collapse between 8k and 12k tokens. 
+              The friction rate typically doubles past this point as the 'lost in the middle' phenomenon 
+              degrades grounding."
+            </p>
+            <div class="text-[10px] font-mono uppercase tracking-widest text-midnight-violet-950/30 text-center">Typical Inflection Pattern</div>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -1066,162 +725,67 @@ unlost config llm anthropic --model claude-3-5-sonnet-20241022</code></pre>
 
       <div class="space-y-14">
 
-        <!-- Trajectory Sensing -->
+        <!-- Recording -->
+        <div id="silent-observer">
+           <h3 class="text-base sm:text-lg font-semibold mb-3">Recording: The Silent Observer</h3>
+           <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
+             Unlost is designed to be invisible until you need it. The recording architecture prioritizes your flow above all else:
+           </p>
+           <div class="space-y-5">
+             <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+               <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Process Isolation</div>
+               <p class="text-sm text-midnight-violet-950/60 leading-relaxed">The Unlost daemon runs as a separate sidecar process. Your agent (Claude, OpenCode) talks to it via a lightweight shim that fires-and-forgets. If Unlost crashes or hangs, your agent keeps working.</p>
+             </div>
+             <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+               <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Async Processing</div>
+               <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Heavy lifting (LLM extraction, embedding generation, graph analysis) happens asynchronously in the background. The shim returns control to the agent immediately.</p>
+             </div>
+             <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+               <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Content-Addressed Deduplication</div>
+               <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Flush jobs are hashed by content. If an agent loops or retries the same output, Unlost silently suppresses the duplicates (within a 45s window) to keep your history clean.</p>
+             </div>
+           </div>
+        </div>
+
+        <!-- Grounding -->
+        <div id="code-graph">
+           <h3 class="text-base sm:text-lg font-semibold mb-3">Grounding: The Code Graph</h3>
+           <p class="text-midnight-violet-950/60 leading-relaxed mb-4">
+             Drift happens when an agent hallucinates symbols that don't exist. Unlost prevents this by maintaining a live graph of your codebase.
+           </p>
+           <div class="space-y-5">
+             <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+               <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">unfault-core + petgraph</div>
+               <p class="text-sm text-midnight-violet-950/60 leading-relaxed">
+                 We use <a href="https://github.com/unfault/core" class="text-fiery-terracotta hover:underline">unfault-core</a> to parse your code and build a dependency graph in milliseconds. It handles symbol resolution, identifying which functions call which, and calculating centrality scores.
+               </p>
+             </div>
+             <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+               <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Symbol Verification</div>
+               <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Every time an agent mentions a file or function, we verify it against the graph. If it exists, we link the capsule to that node. If it doesn't, we flag it as potential drift.</p>
+             </div>
+             <div class="border-l-2 border-fiery-terracotta/20 pl-4">
+               <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Git Provenance</div>
+               <p class="text-sm text-midnight-violet-950/60 leading-relaxed">We capture the git HEAD SHA at the start and end of every turn. This allows us to time-travel: we know exactly what the code looked like when a decision was made, even if it has changed since.</p>
+             </div>
+           </div>
+        </div>
+
+        <!-- Storage & Infrastructure (Remainder) -->
         <div>
-          <h3 class="text-xs font-semibold text-midnight-violet-950/30 mb-6 uppercase tracking-wider">Trajectory Sensing</h3>
+          <h3 class="text-base sm:text-lg font-semibold mb-3">Storage &amp; Retrieval</h3>
           <div class="space-y-5">
             <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Three-state FSM</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Stable → Watch → Intervene controller with hysteresis and per-basin cooldowns. Powers every proactive intervention.</p>
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Apache Arrow / LanceDB</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Capsules are stored locally as Arrow RecordBatches with three indexes: ANN (vector search), LabelList (tag filtering), and Scalar (time). It's fast, private, and zero-config.</p>
             </div>
             <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Weighted multi-channel basin scoring</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Loop, Spec, and Drift intensities are calibrated weighted sums of 10 independent symptom channels. This signal drives <code>metrics</code> and all interventions.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">EMA smoothing</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">All 10 channels smoothed with exponential moving average (α=0.3) to suppress single-turn noise spikes before scoring.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Sliding window persistence</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">State only escalates after 3 consecutive turns above the 0.75 threshold. One-turn spikes never trigger an intervention.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Coffee Pause soft decay</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">&gt;30-minute gaps decay intensity to 0.3× and reset the FSM to Stable. On return, a resumption brief is injected to re-orient the agent. Used by the trajectory controller and <code>brief</code>.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Grounding stall detection</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">User-mentioned file paths are tracked with exponential time decay; a stall streak increments whenever the agent's response ignores them. Feeds the Drift basin.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Jaccard-like logic churn</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Word-set distance between consecutive agent decisions detects rapid plan changes without progress. Feeds the Loop basin and the Stubbornness boost.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Symbol repetition / novelty collapse</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Fraction of capsule symbols seen in the last 8 capsules; its complement is the novelty score. Both feed the Loop basin and are visible in <code>metrics</code>.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Stubbornness boost</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Extra intensity when alignment debt is high but decision churn is low. The agent acknowledges errors but keeps the same plan. Triggers a Spec-basin escalation.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Blind Acceptance risk</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Detects fluent long agent responses followed by passive short user replies; flags over-trust risk and boosts Spec intensity before an intervention fires.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Summary intent damping</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Multiplies raw intensity by 0.6 on turns the agent is legitimately consolidating. Prevents false positives during wrap-up phases.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Stratified intervention policy</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Ambient hint (&lt;0.8), Structural note (≥0.8), Emergency hard-stop (&gt;0.95). Intervention severity scales with signal confidence.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Hydration packet</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">For Loop interventions, the 3 most relevant recent capsules are selected by scoring recency, symbol overlap, emotion, effort, and failure mode. These are injected into the intervention text to help the agent break the loop.</p>
+              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">HyPE Embeddings</div>
+              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">We use Hypothetical Prompt Embeddings (HyPE). At indexing time, we generate questions the capsule answers. At retrieval time, we frame your query as a question. Matching questions-to-questions is significantly more accurate than matching queries-to-documents.</p>
             </div>
           </div>
         </div>
-
-        <!-- Emotion & NLP -->
-        <div>
-          <h3 class="text-xs font-semibold text-midnight-violet-950/30 mb-6 uppercase tracking-wider">Emotion &amp; NLP</h3>
-          <div class="space-y-5">
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Multi-label emotion classification</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">RoBERTa-base fine-tuned on GoEmotions (28 labels → 8 buckets), running fully locally via ONNX Runtime. Feeds affective modulation and Spec basin scoring.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Heuristic emotion override</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Pattern-based frustration and doubt detection corrects neural model misclassifications. Sarcasm, repetition complaints, and hedging phrases are caught even when the model doesn't fire.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Affective modulation</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Joy halves trajectory intensity. Persistent anger across ≥2 turns triggers a de-escalation override that fires regardless of basin state. Based on <a href="https://dl.acm.org/doi/full/10.1145/3756681.3756951" class="text-fiery-terracotta hover:underline">EASE'25</a> research on emotional strain in LLM interactions.</p>
-            </div>
-          </div>
-        </div>
-
-        <!-- Retrieval & Memory -->
-        <div>
-          <h3 class="text-xs font-semibold text-midnight-violet-950/30 mb-6 uppercase tracking-wider">Retrieval &amp; Memory</h3>
-          <div class="space-y-5">
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">HyPE - Hypothetical Prompt Embeddings</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">At indexing time, the LLM generates 2–3 questions each capsule answers. At retrieval time, <code>recall</code>, <code>trace</code>, <code>challenge</code>, <code>explore</code>, and <code>brief</code> each frame your query as a matching question before embedding. This turns retrieval into a question-to-question match with no extra LLM cost. <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5139335" class="text-fiery-terracotta hover:underline" target="_blank" rel="noopener">Ma et al., 2025</a>.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Trajectory-encoded embeddings</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Each capsule is embedded with its category, failure mode, symbols, and the prior decision from the same work thread. Causally related capsules cluster together across sessions. Used by every retrieval command.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">BGE-small-en-v1.5 dense embeddings</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">384-dimensional vectors generated fully locally via fastembed + ONNX Runtime. Never sent to a remote service.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">ANN vector search</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">LanceDB <code>nearest_to</code> with an auto-tuned approximate nearest-neighbour index on the embedding column. The seed step in every retrieval command.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">LabelList index</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Scalar index on the symbols array column enabling fast <code>array_contains</code> fan-out queries. Used by <code>trace</code> to expand the causal chain.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Causal chain algorithm</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">ANN seed → symbol fan-out via LabelList index → similarity threshold pruning → chronological sort. Powers <code>trace</code> to reconstruct the sequence of decisions that explain the current state of any file or concept.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Cross-session recurrence scoring</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Capsules scored for <code>brief</code> by failure mode weight, explicit rationale and decision presence, and symbols recurring across multiple distinct sessions. No recency bias.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Recency-weighted fingerprint deduplication</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed"><code>recall</code> collapses near-duplicates by content fingerprint and caps older sessions at 3 results, with a 30-minute recency bypass for fresh capsules.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Checkpoint summarization</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">A background process compresses windows of capsules into narrative checkpoints. <code>recall</code> and <code>brief</code> use a fast path when the delta since the last checkpoint is small. Reduces LLM token cost significantly.</p>
-            </div>
-          </div>
-        </div>
-
-        <!-- Storage & Infrastructure -->
-        <div>
-          <h3 class="text-xs font-semibold text-midnight-violet-950/30 mb-6 uppercase tracking-wider">Storage &amp; Infrastructure</h3>
-          <div class="space-y-5">
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Apache Arrow / LanceDB columnar store</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Capsules stored as Arrow RecordBatches with three indexes (ANN, LabelList, scalar timestamp). Append-only with schema evolution. The foundation every command reads from.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Code graph analysis</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed"><a href="https://github.com/unfault/core" class="text-fiery-terracotta hover:underline font-mono text-sm">unfault-core</a> + petgraph builds a live static graph for centrality scoring, dependency/impact traversal, and symbol validation. Used by <code>brief</code> to expand scope and by Drift detection to validate agent-mentioned identifiers.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">LLM structured extraction</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">JSON Schema extraction via rig-core + schemars produces typed <code>IntentCapsule</code> structs from raw agent exchanges. Works with any provider - Anthropic, OpenAI, Ollama.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Hybrid extraction mode</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Heuristics identify "pivotal" turns before invoking the LLM. Routine exchanges are skipped, reducing extraction cost without losing signal.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">SHA-256 job deduplication</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Flush jobs hashed by content; identical jobs within a 45-second window are suppressed. Also used to derive stable workspace IDs from git remote URLs.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Git grounding &amp; SHA provenance</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">Git HEAD and commit SHAs stored on every capsule. Git commits ingested as first-class capsules deduplicated by hash. Surfaced by <code>brief</code>, <code>trace</code>, <code>challenge</code>, and <code>explore</code>.</p>
-            </div>
-            <div class="border-l-2 border-fiery-terracotta/20 pl-4">
-              <div class="font-mono text-sm font-semibold text-midnight-violet-950 mb-1">Changelog ingestion</div>
-              <p class="text-sm text-midnight-violet-950/60 leading-relaxed">CHANGELOG.md versions parsed and stored as versioned capsules, surfaced with <code>ref=version:vX.Y.Z</code> citations in LLM prompts. Used by <code>challenge</code> and <code>brief</code> for version-aware context.</p>
-            </div>
-          </div>
-        </div>
-
+        
       </div>
     </div>
   </section>
@@ -1301,7 +865,7 @@ unlost config llm anthropic --model claude-3-5-sonnet-20241022</code></pre>
         If something feels rough, open an issue. I read them.
         <a href="https://github.com/unfault/unlost/issues" class="text-fiery-terracotta hover:underline">github.com/unfault/unlost/issues</a>
       </p>
-      <p class="text-midnight-violet-950/50 mt-6">- mcfly</p>
+      <p class="text-midnight-violet-950/50 mt-6">- Sylvain</p>
     </div>
   </section>
 
@@ -1309,7 +873,7 @@ unlost config llm anthropic --model claude-3-5-sonnet-20241022</code></pre>
   <!-- Footer -->
   <footer class="py-8 sm:py-12 px-4">
     <div class="max-w-2xl mx-auto flex flex-col sm:flex-row items-center justify-between text-sm text-midnight-violet-950/40 gap-4">
-      <span class="text-center sm:text-left">MIT License · © 2026 mcfly Hellegouarch</span>
+      <span class="text-center sm:text-left">MIT License · © 2026 Sylvain Hellegouarch</span>
       <div class="flex items-center gap-4">
         <a href="https://github.com/unfault/unlost" class="text-midnight-violet-950/60 hover:text-fiery-terracotta transition-colors">GitHub</a>
         <a href="https://unfault.dev" class="text-midnight-violet-950/60 hover:text-fiery-terracotta transition-colors">unfault.dev</a>


### PR DESCRIPTION
## Summary
- Rewrite `docs/index.html` "How It Works" to focus on the Memory Lifecycle (Record, Extract, Ground)
- Move "Long Memory" section up to emphasize the core value proposition (Context Ownership)
- Create new "Cognitive Mirror" section for deep technical details (Friction, Emotions, Metrics)
- Simplify navigation to Install/Commands/GitHub only

## Changelog
- **`docs/index.html`**: Restructured landing page to prioritize Context Ownership and Memory over control. "How It Works" now follows the Memory Lifecycle (Record → Extract → Ground). Added "One Memory. Many Lenses" section to showcase `trace`, `challenge`, and `explore` as different views on the same grounded context. Moved "Cognitive Mirror" technical details to a dedicated deep-dive section at the bottom.