### PR TITLE
feat: add per-turn TurnEval metadata for unlost reflect foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **`TurnEval`**: Per-turn evaluation metadata computed on-the-fly at flush time with zero LLM calls. Each capsule now carries 12 agent-tuning (diagnose) dimensions — persisted governor `SymptomChannels` previously discarded after friction decisions — plus 5 developer coaching dimensions: `clarity` (request specificity), `context_freshness` (cache ratio + frustration slope, captures compaction signal), `verification_rigor` (tool outcome presence), `decision_progress` (decision/symbol diff from prior turn), and `scope_discipline` (symbol spread + category diversity). Behavioral flags (`session_heavy`, `session_too_long`, `retry_loop`, `blind_acceptance`, etc.) are derived from thresholds on both dimensions. Stored in LanceDB (`te_*` columns with schema evolution), JSONL capsule log, and metrics events. Displayed in `unlost inspect`. Designed to power `unlost reflect` in a subsequent release — a reflect-time LLM can reconstruct session quality from structured telemetry only, with no raw transcript required.
+
 ## [0.12.0] - 2026-02-27
 
 ### Added

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -278,6 +278,7 @@ pub async fn ingest_changelog(
             None,
             None,
             &capsule,
+            &crate::types::TurnEval::default(),
             None,
             None, // head_sha: not applicable for changelog ingestion
             None, // commit_sha: not applicable for changelog ingestion

--- a/src/commands/brief.rs
+++ b/src/commands/brief.rs
@@ -199,6 +199,7 @@ fn checkpoint_as_capsule_hit(
         assistant_emotion: None,
         head_sha: None,
         commit_sha: None,
+        turn_eval: None,
     }
 }
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -647,7 +647,8 @@ pub async fn run(
 
     for (cap, meta) in capsules {
         crate::storage::insert_capsule_row(
-            &db, &embedder, 0, 0, now_ms, &meta, None, None, &cap, None, None, None,
+            &db, &embedder, 0, 0, now_ms, &meta, None, None, &cap,
+            &crate::types::TurnEval::default(), None, None, None,
         )
         .await
         .ok();

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -143,6 +143,46 @@ pub async fn run(
                         println!("question[{}]: {}", i, q);
                     }
                 }
+                if let Some(ref te) = hit.turn_eval {
+                    println!(
+                        "turn_eval: {} intensity={:.2} state={:?}",
+                        te.version, te.trajectory_intensity, te.trajectory_state
+                    );
+                    println!(
+                        "  diagnose: rep={:.2} nov={:.2} sem={:.2} eff={:.2} align={:.2} \
+                         hall={:.2} stall={:.2} inst={:.2} churn={:.2} fluency={:.2}",
+                        te.repetition,
+                        te.novelty_collapse,
+                        te.semantic_stall,
+                        te.effort_spike,
+                        te.alignment_debt,
+                        te.path_hallucination,
+                        te.grounding_stall,
+                        te.instruction_staticness,
+                        te.logic_churn,
+                        te.fluency
+                    );
+                    println!(
+                        "  coach:    clarity={:.2} freshness={:.2} verify={:.2} \
+                         progress={:.2} scope={:.2}",
+                        te.clarity,
+                        te.context_freshness,
+                        te.verification_rigor,
+                        te.decision_progress,
+                        te.scope_discipline
+                    );
+                    if !te.flags.is_empty() {
+                        println!("  flags:    {:?}", te.flags);
+                    }
+                    if !te.outcome_hint.is_empty() && te.outcome_hint != "unclear" {
+                        println!("  outcome:  {}", te.outcome_hint);
+                    }
+                    if !te.evidence.is_empty() {
+                        for ev in &te.evidence {
+                            println!("  evidence: {}", ev);
+                        }
+                    }
+                }
                 println!();
             }
             Ok(())

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -278,6 +278,7 @@ fn checkpoint_as_capsule_hit(
         assistant_emotion: None,
         head_sha: None,
         commit_sha: None,
+        turn_eval: None,
     }
 }
 

--- a/src/companion/flow.rs
+++ b/src/companion/flow.rs
@@ -155,6 +155,8 @@ struct BackgroundState {
     /// uses this as `prior_decision` in the embed text, even if the chunker's buffer
     /// was flushed before the worker finished.
     last_decisions: HashMap<String, String>,
+    /// Cumulative turn count per agent session ID, used to compute context_freshness.
+    session_turn_counts: HashMap<String, usize>,
 }
 
 impl BackgroundState {
@@ -172,6 +174,7 @@ impl BackgroundState {
             extraction_mode,
             llm_calls: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             last_decisions: HashMap::new(),
+            session_turn_counts: HashMap::new(),
         }
     }
 
@@ -523,10 +526,12 @@ impl Flow {
         let commit_mentioned = looks_like_commit_or_pr(&exchange_text);
         let conn_id = CONN_SEQ.fetch_add(1, Ordering::Relaxed);
 
-        // Sticky session ID for the controller + session transition detection
-        let final_session_id = {
+        // Sticky session ID for the controller + session transition detection.
+        // Also grab the last governor channels snapshot for TurnEval construction.
+        let (final_session_id, turn_eval_channels) = {
             let controller = self.state.controllers.entry(ws.id.clone()).or_default();
             let prev_session = controller.last_agent_session_id.clone();
+            let channels = controller.last_channels.take();
             if let Some(ref sid) = event.agent_session_id {
                 controller.last_agent_session_id = Some(sid.clone());
             }
@@ -555,10 +560,11 @@ impl Flow {
                 }
             }
 
-            event
+            let sid = event
                 .agent_session_id
                 .clone()
-                .or_else(|| controller.last_agent_session_id.clone())
+                .or_else(|| controller.last_agent_session_id.clone());
+            (sid, channels)
         };
 
         let item = ChunkInput {
@@ -573,6 +579,7 @@ impl Flow {
             grounding_note: event.grounding_note,
             source_ts_ms: event.source_ts_ms,
             workspace_root: ws.root.clone(),
+            turn_eval_channels,
         };
 
         // Ingest into chunker (may or may not produce a flush job depending on boundaries).
@@ -794,6 +801,97 @@ async fn process_flush_job(
         metrics_jsonl: ws_dir.join("metrics.jsonl"),
     };
 
+    // ── Build TurnEval ────────────────────────────────────────────────────────
+    // All heuristic — zero LLM calls. Uses:
+    // (a) Governor channels snapshot carried in from check_friction via ChunkInput.
+    // (b) Coach scores derived from the capsule + prior history + exchange text.
+    let turn_eval = {
+        // Query recent capsule history for coach scoring. Best-effort; empty on error.
+        // We take the last 8 capsules regardless of session — recent history is what matters
+        // for scoring clarity, scope, and progress.
+        let history = match crate::storage::scan_capsules_lancedb(
+            &ws, 8, None, None, None, None, None,
+        )
+        .await
+        {
+            Ok(h) => h,
+            Err(_) => vec![],
+        };
+
+        // Resolve session turn count from background state.
+        let session_turn_count = {
+            let mut st = state.lock().await;
+            let sid = job.meta.agent_session_id.as_deref().unwrap_or("__none__");
+            let count = st.session_turn_counts.entry(sid.to_string()).or_insert(0);
+            *count += 1;
+            *count
+        };
+
+        let coach_input = crate::governor::CoachInput {
+            capsule: &capsule,
+            history: &history,
+            exchange_text: &job.input,
+            usage: job.meta.usage.as_ref(),
+            session_turn_count,
+        };
+        let coach = crate::governor::compute_coach_scores(&coach_input);
+
+        // Unpack governor channels (may be None for replayed/non-live turns).
+        let (channels, traj_intensity, traj_state) = job
+            .turn_eval_channels
+            .clone()
+            .unwrap_or_default();
+
+        let flags = crate::governor::compute_flags(
+            &channels,
+            traj_intensity,
+            &coach,
+            session_turn_count,
+        );
+
+        // Combine evidence from coach + any flag evidence.
+        let mut evidence = coach.evidence.clone();
+        if channels.path_hallucination > 0.5 {
+            evidence.push(format!(
+                "path_hallucination={:.2} (agent referenced non-existent files)",
+                channels.path_hallucination
+            ));
+        }
+        if channels.alignment_debt > 0.4 {
+            evidence.push(format!(
+                "alignment_debt={:.2} (repeated user corrections detected)",
+                channels.alignment_debt
+            ));
+        }
+
+        crate::types::TurnEval {
+            version: "v1".to_string(),
+            // Agent tuning (diagnose)
+            repetition: channels.repetition,
+            novelty_collapse: channels.novelty_collapse,
+            semantic_stall: channels.semantic_stall,
+            effort_spike: channels.effort_spike,
+            alignment_debt: channels.alignment_debt,
+            path_hallucination: channels.path_hallucination,
+            grounding_stall: channels.grounding_stall,
+            instruction_staticness: channels.instruction_staticness,
+            logic_churn: channels.logic_churn,
+            fluency: channels.fluency,
+            trajectory_intensity: traj_intensity,
+            trajectory_state: traj_state,
+            // Developer coaching
+            clarity: coach.clarity,
+            context_freshness: coach.context_freshness,
+            verification_rigor: coach.verification_rigor,
+            decision_progress: coach.decision_progress,
+            scope_discipline: coach.scope_discipline,
+            // Flags + outcome
+            flags,
+            outcome_hint: "unclear".to_string(),
+            evidence,
+        }
+    };
+
     // Append to JSONL (cheap, local)
     append_capsule_jsonl(
         &ws.capsules_jsonl,
@@ -802,6 +900,7 @@ async fn process_flush_job(
         job.exchange_seq,
         &job.meta,
         &capsule,
+        &turn_eval,
         job.head_sha.as_deref(),
         job.commit_sha.as_deref(),
     )?;
@@ -815,6 +914,7 @@ async fn process_flush_job(
         user_emotion.as_ref(),
         assistant_emotion.as_ref(),
         &capsule,
+        &turn_eval,
     );
 
     // Insert into LanceDB
@@ -833,6 +933,7 @@ async fn process_flush_job(
         user_emotion.as_ref(),
         assistant_emotion.as_ref(),
         &capsule,
+        &turn_eval,
         prior_decision.as_deref(),
         job.head_sha.as_deref(),
         job.commit_sha.as_deref(),
@@ -864,6 +965,7 @@ fn append_capsule_jsonl(
     exchange_seq: u64,
     meta: &crate::ResponseMeta,
     capsule: &IntentCapsule,
+    turn_eval: &crate::types::TurnEval,
     head_sha: Option<&str>,
     commit_sha: Option<&str>,
 ) -> anyhow::Result<()> {
@@ -901,6 +1003,7 @@ fn append_capsule_jsonl(
         "agent_session_id": meta.agent_session_id,
         "usage": usage,
         "capsule": capsule,
+        "turn_eval": turn_eval,
         "head_sha": head_sha,
         "commit_sha": commit_sha,
     });

--- a/src/git.rs
+++ b/src/git.rs
@@ -239,6 +239,7 @@ pub async fn ingest_git_commits(
             None,
             None,
             &capsule,
+            &crate::types::TurnEval::default(),
             Some(&embed_text),
             None, // head_sha: not applicable for git history ingestion
             None, // commit_sha: not applicable for git history ingestion
@@ -491,6 +492,7 @@ pub async fn ingest_git_tags(
             None,
             None,
             &capsule,
+            &crate::types::TurnEval::default(),
             Some(&embed_text),
             None, // head_sha: not applicable for git tag ingestion
             None, // commit_sha: not applicable for git tag ingestion

--- a/src/governor.rs
+++ b/src/governor.rs
@@ -58,6 +58,10 @@ pub struct TrajectoryController {
     pub last_decision: Option<String>,
     /// The last agent session ID seen in this workspace.
     pub last_agent_session_id: Option<String>,
+    /// Snapshot of (smoothed_channels, intensity, state) captured at the end of the most
+    /// recent `update()` call. Read by `record_turn` so the background worker can persist
+    /// them into the capsule without re-deriving EMA state.
+    pub last_channels: Option<(SymptomChannels, f32, TrajectoryState)>,
 }
 
 const CORRECTION_PATTERNS: &[&str] = &[
@@ -454,6 +458,10 @@ impl TrajectoryController {
         if reset_note.is_some() {
             note = reset_note;
         }
+
+        // Stash channels so record_turn can copy them into ChunkInput without
+        // re-deriving EMA state in the background worker.
+        self.last_channels = Some((self.smoothed_channels.clone(), self.intensity, self.state));
 
         TrajectoryUpdate {
             state: self.state,
@@ -1105,6 +1113,371 @@ pub fn detect_failure_keywords(text: &str) -> Option<crate::types::FailureMode> 
         return Some(crate::types::FailureMode::Drift);
     }
     None
+}
+
+// ============================================================================
+// TurnEval: Developer coaching score computation (all heuristic, zero LLM)
+// ============================================================================
+
+/// Inputs fed to the coach scorer from the background flush worker.
+pub struct CoachInput<'a> {
+    /// The freshly-extracted capsule for this turn.
+    pub capsule: &'a IntentCapsule,
+    /// Recent prior capsules in this session (newest first).
+    pub history: &'a [CapsuleHit],
+    /// Raw exchange text (user + assistant combined) for the turn.
+    pub exchange_text: &'a str,
+    /// Token usage for this turn (used for context_freshness cache ratio).
+    pub usage: Option<&'a crate::types::UsageMeta>,
+    /// Number of turns in this session so far (including this one).
+    pub session_turn_count: usize,
+}
+
+/// Returned coach dimension scores (0.0–1.0 each, higher = healthier).
+#[derive(Debug, Clone, Default)]
+pub struct CoachScores {
+    pub clarity: f32,
+    pub context_freshness: f32,
+    pub verification_rigor: f32,
+    pub decision_progress: f32,
+    pub scope_discipline: f32,
+    /// Short auditable evidence strings.
+    pub evidence: Vec<String>,
+}
+
+/// Patterns indicating a tool outcome was verified (build/test results).
+const VERIFICATION_PASS_PATTERNS: &[&str] = &[
+    "succeeded",
+    "tests passed",
+    "test passed",
+    "all tests",
+    "cargo test",
+    "npm test",
+    "pytest",
+    "build ok",
+    "✓",
+    "✔",
+    "passing",
+    "0 failed",
+];
+
+const VERIFICATION_FAIL_PATTERNS: &[&str] = &[
+    "failed",
+    "error",
+    "exit code",
+    "FAILED",
+    "panicked",
+    "assertion failed",
+    "stderr",
+    "status 1",
+];
+
+const CODE_TOUCHING_CATEGORIES: &[&str] = &[
+    "implementation",
+    "refactoring",
+    "debugging",
+    "fix",
+    "cli_feature_update",
+];
+
+/// Compute developer coaching scores for a single turn.
+/// All heuristic — no LLM calls, no I/O.
+pub fn compute_coach_scores(input: &CoachInput<'_>) -> CoachScores {
+    let mut evidence: Vec<String> = Vec::new();
+
+    // ── clarity ─────────────────────────────────────────────────────────────
+    // High when: intent is long enough, symbols present, low alignment_debt in
+    // the prior turn (meaning the previous response didn't need correction).
+    let clarity = {
+        let intent_len = input.capsule.intent.len();
+        let sym_count = input.capsule.user_symbols.len() + input.capsule.symbols.len();
+
+        // Normalise intent length: <20 chars = 0.0, >=150 chars = 1.0
+        let len_score = (intent_len as f32 / 150.0).min(1.0);
+
+        // Symbol specificity: 0 symbols = 0.0, 3+ = 1.0
+        let sym_score = (sym_count as f32 / 3.0).min(1.0);
+
+        // Correction penalty: if history[0] had high alignment_debt, the user
+        // probably had to correct — reduce clarity of this new request.
+        let correction_penalty = input
+            .history
+            .first()
+            .and_then(|h| h.turn_eval.as_ref())
+            .map(|te| te.alignment_debt * 0.4)
+            .unwrap_or(0.0);
+
+        let raw = (len_score * 0.45 + sym_score * 0.55) - correction_penalty;
+
+        if intent_len < 20 {
+            evidence.push("intent too short to be precise".to_string());
+        }
+        if sym_count == 0 {
+            evidence.push("no symbols specified in request".to_string());
+        }
+
+        raw.clamp(0.0, 1.0)
+    };
+
+    // ── context_freshness ────────────────────────────────────────────────────
+    // Decays when:
+    // (a) cache_read/tokens_input ratio drops (context being squeezed / compaction)
+    // (b) trajectory intensity has been rising for 2+ consecutive turns
+    // (c) session turn count is very high (heavy session)
+    let context_freshness = {
+        // Cache ratio: high ratio = context being served from cache (healthy).
+        // Low ratio = fresh tokens dominating (context rotating / compaction triggered).
+        let cache_ratio = input.usage.and_then(|u| {
+            let cache_read = u.tokens_cache_read.unwrap_or(0);
+            let input_tokens = u.tokens_input.unwrap_or(0);
+            if input_tokens > 0 {
+                Some(cache_read as f32 / input_tokens as f32)
+            } else {
+                None
+            }
+        });
+
+        let cache_score: f32 = match cache_ratio {
+            Some(r)
+                if r < 0.2 && input.usage.and_then(|u| u.tokens_input).unwrap_or(0) > 10_000 =>
+            {
+                // Low cache ratio with high input tokens = likely compaction
+                evidence.push(format!(
+                    "low cache hit ratio ({:.0}%) with high input tokens — possible context compaction",
+                    r * 100.0
+                ));
+                0.2
+            }
+            Some(r) if r < 0.4 => 0.5,
+            Some(_) => 1.0,
+            None => 0.8, // No usage data — neutral
+        };
+
+        // Frustration slope: check if last 2+ turns had rising intensity
+        let frustration_slope = if input.history.len() >= 2 {
+            let intensities: Vec<f32> = input
+                .history
+                .iter()
+                .take(3)
+                .filter_map(|h| h.turn_eval.as_ref())
+                .map(|te| te.trajectory_intensity)
+                .collect();
+            if intensities.len() >= 2 && intensities[0] > intensities[1] + 0.1 {
+                evidence
+                    .push("trajectory intensity rising — agent may be losing context".to_string());
+                0.3 // penalise freshness when frustration is escalating
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+
+        // Heavy session penalty: high turn count
+        let session_penalty = if input.session_turn_count > 40 {
+            evidence.push(format!(
+                "session has {} turns — context may be stale",
+                input.session_turn_count
+            ));
+            0.3
+        } else if input.session_turn_count > 20 {
+            0.1
+        } else {
+            0.0
+        };
+
+        (cache_score - frustration_slope - session_penalty).clamp(0.0_f32, 1.0_f32)
+    };
+
+    // ── verification_rigor ───────────────────────────────────────────────────
+    // High when the exchange contains tool outcome strings (pass/fail).
+    // Lower when a code-touching category produced no verification evidence.
+    let verification_rigor = {
+        let lower = input.exchange_text.to_lowercase();
+        let has_pass = VERIFICATION_PASS_PATTERNS.iter().any(|p| lower.contains(p));
+        let has_fail = VERIFICATION_FAIL_PATTERNS
+            .iter()
+            .any(|p| lower.contains(&p.to_lowercase()));
+        let is_code_touching = CODE_TOUCHING_CATEGORIES
+            .iter()
+            .any(|c| input.capsule.category.to_lowercase().contains(c));
+
+        if has_pass {
+            1.0
+        } else if has_fail {
+            // Failure is still verification — the agent checked.
+            0.8
+        } else if is_code_touching {
+            // Code was likely changed but no tool outcome found.
+            evidence.push("code-touching turn with no build/test outcome found".to_string());
+            0.2
+        } else {
+            // Non-code turn: not applicable, neutral.
+            0.7
+        }
+    };
+
+    // ── decision_progress ────────────────────────────────────────────────────
+    // High when: new decision text (different from prior), new symbols appearing,
+    // or category advancing (e.g. planning → implementation).
+    let decision_progress = {
+        let prior = input.history.first();
+        match prior {
+            None => 0.8, // First turn: assume progress
+            Some(prev) => {
+                // Decision text similarity (simple: shared token overlap)
+                let new_dec = input.capsule.decision.to_lowercase();
+                let old_dec = prev.capsule.decision.to_lowercase();
+                let new_words: std::collections::HashSet<&str> =
+                    new_dec.split_whitespace().collect();
+                let old_words: std::collections::HashSet<&str> =
+                    old_dec.split_whitespace().collect();
+                let overlap = if old_words.is_empty() {
+                    0.0
+                } else {
+                    new_words.intersection(&old_words).count() as f32 / old_words.len() as f32
+                };
+                // High overlap = stalled decision
+                let decision_novelty = 1.0 - overlap.min(1.0);
+
+                // New symbols compared to last turn
+                let prior_syms: std::collections::HashSet<&str> =
+                    prev.capsule.symbols.iter().map(|s| s.as_str()).collect();
+                let new_syms: std::collections::HashSet<&str> =
+                    input.capsule.symbols.iter().map(|s| s.as_str()).collect();
+                let new_sym_count = new_syms.difference(&prior_syms).count();
+                let sym_novelty = (new_sym_count as f32 / 3.0_f32).min(1.0);
+
+                let progress = decision_novelty * 0.6 + sym_novelty * 0.4;
+
+                if progress < 0.2 {
+                    evidence.push(
+                        "decision text and symbols unchanged from prior turn — possible stall"
+                            .to_string(),
+                    );
+                }
+                progress.clamp(0.0, 1.0)
+            }
+        }
+    };
+
+    // ── scope_discipline ─────────────────────────────────────────────────────
+    // High when symbol set stays focused; drops when many new unresolved symbols
+    // accumulate across recent turns without corresponding resolution.
+    let scope_discipline = {
+        if input.history.len() < 3 {
+            1.0 // Not enough history to judge scope creep
+        } else {
+            // Count distinct symbols across last N turns
+            let mut all_syms: std::collections::HashSet<&str> = std::collections::HashSet::new();
+            let window = input.history.iter().take(5);
+            for h in window {
+                for s in &h.capsule.symbols {
+                    all_syms.insert(s.as_str());
+                }
+            }
+            let symbol_spread = all_syms.len();
+
+            // Category diversity: distinct categories in recent history
+            let distinct_cats: std::collections::HashSet<&str> = input
+                .history
+                .iter()
+                .take(5)
+                .map(|h| h.capsule.category.as_str())
+                .collect();
+            let cat_diversity = distinct_cats.len();
+
+            // Symbol spread > 12 across 5 turns = scope concern
+            let sym_score: f32 = if symbol_spread > 15 {
+                evidence.push(format!(
+                    "{} distinct symbols across last 5 turns — possible scope creep",
+                    symbol_spread
+                ));
+                0.2
+            } else if symbol_spread > 8 {
+                0.5
+            } else {
+                1.0
+            };
+
+            // High category diversity is OK if progressive (planning→impl→test);
+            // penalise only if it looks like thrashing (>3 distinct cats in 5 turns).
+            let cat_score = if cat_diversity > 3 {
+                evidence.push(format!(
+                    "{} distinct categories in last 5 turns — possible topic thrashing",
+                    cat_diversity
+                ));
+                0.4
+            } else {
+                1.0
+            };
+
+            (sym_score * 0.6 + cat_score * 0.4).clamp(0.0_f32, 1.0_f32)
+        }
+    };
+
+    CoachScores {
+        clarity,
+        context_freshness,
+        verification_rigor,
+        decision_progress,
+        scope_discipline,
+        evidence,
+    }
+}
+
+/// Derive behavioral flags from combined diagnose + coach scores.
+pub fn compute_flags(
+    channels: &SymptomChannels,
+    intensity: f32,
+    coach: &CoachScores,
+    session_turn_count: usize,
+) -> Vec<String> {
+    let mut flags: Vec<String> = Vec::new();
+
+    // ── Agent tuning flags ───────────────────────────────────────────────────
+    if channels.repetition > 0.55 {
+        flags.push("retry_loop".to_string());
+    }
+    if channels.logic_churn > 0.50 {
+        flags.push("high_churn".to_string());
+    }
+    if channels.path_hallucination > 0.50 {
+        flags.push("hallucination_risk".to_string());
+    }
+    if channels.alignment_debt > 0.45 {
+        flags.push("instruction_drift".to_string());
+    }
+    if channels.fluency > 0.60 {
+        flags.push("blind_acceptance".to_string());
+    }
+    if intensity >= THRESHOLD_INTERVENE {
+        flags.push("trajectory_critical".to_string());
+    } else if intensity >= THRESHOLD_WATCH {
+        flags.push("trajectory_watch".to_string());
+    }
+
+    // ── Developer coaching flags ─────────────────────────────────────────────
+    if coach.clarity < 0.30 {
+        flags.push("needs_clarification".to_string());
+    }
+    if coach.context_freshness < 0.40 {
+        // Context is heavy — not a problem per se, worth noting
+        flags.push("session_heavy".to_string());
+    }
+    if coach.verification_rigor < 0.25 {
+        flags.push("unverified_claim".to_string());
+    }
+    if coach.scope_discipline < 0.35 {
+        flags.push("scope_shift".to_string());
+    }
+
+    // ── Combined / meta flags ────────────────────────────────────────────────
+    if session_turn_count > 40 && coach.context_freshness < 0.50 {
+        flags.push("session_too_long".to_string());
+    }
+
+    flags
 }
 
 #[cfg(test)]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,6 +22,18 @@ pub(crate) enum MetricsEvent {
         assistant_emotion: Option<String>,
         /// Failure mode detected by LLM semantic analysis
         failure_mode: Option<String>,
+        /// TurnEval: composite trajectory intensity (diagnose)
+        #[serde(default)]
+        te_intensity: Option<f32>,
+        /// TurnEval: developer coaching clarity score
+        #[serde(default)]
+        te_clarity: Option<f32>,
+        /// TurnEval: context freshness score
+        #[serde(default)]
+        te_context_freshness: Option<f32>,
+        /// TurnEval: behavioral flags (comma-joined)
+        #[serde(default)]
+        te_flags: Option<String>,
     },
     FrictionWarningInjected {
         ts_ms: i64,
@@ -85,6 +97,7 @@ pub(crate) fn record_capsule_saved(
     user_emotion: Option<&crate::emotion::EmotionMeta>,
     assistant_emotion: Option<&crate::emotion::EmotionMeta>,
     capsule: &crate::IntentCapsule,
+    turn_eval: &crate::types::TurnEval,
 ) -> anyhow::Result<()> {
     let (paths_checked, paths_missing) = crate::workspace::validate_paths(&ws.id, &capsule.symbols);
     let (tokens_total, tokens_input, cost) = meta
@@ -101,6 +114,12 @@ pub(crate) fn record_capsule_saved(
         crate::types::FailureMode::RetrySpiral => Some("retry_spiral".to_string()),
         crate::types::FailureMode::FalseProgress => Some("false_progress".to_string()),
         crate::types::FailureMode::UnboundedHorizon => Some("unbounded_horizon".to_string()),
+    };
+
+    let te_flags_str = if turn_eval.flags.is_empty() {
+        None
+    } else {
+        Some(turn_eval.flags.join(","))
     };
 
     let ev = MetricsEvent::CapsuleSaved {
@@ -121,6 +140,22 @@ pub(crate) fn record_capsule_saved(
         user_emotion: user_emotion.map(|e| e.label.clone()),
         assistant_emotion: assistant_emotion.map(|e| e.label.clone()),
         failure_mode: failure_mode_str,
+        te_intensity: if turn_eval.trajectory_intensity > 0.0 {
+            Some(turn_eval.trajectory_intensity)
+        } else {
+            None
+        },
+        te_clarity: if turn_eval.clarity > 0.0 {
+            Some(turn_eval.clarity)
+        } else {
+            None
+        },
+        te_context_freshness: if turn_eval.context_freshness > 0.0 {
+            Some(turn_eval.context_freshness)
+        } else {
+            None
+        },
+        te_flags: te_flags_str,
     };
     append_event(&ws.metrics_jsonl, &ev)
 }

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -218,6 +218,9 @@ pub(crate) struct ChunkInput {
     pub(crate) source_ts_ms: Option<i64>,
     /// Absolute path to the workspace root (git toplevel or directory).
     pub(crate) workspace_root: std::path::PathBuf,
+    /// Governor channels snapshot captured in check_friction for this turn.
+    /// Carries (smoothed_channels, intensity, state) into the background flush worker.
+    pub(crate) turn_eval_channels: Option<(crate::types::SymptomChannels, f32, crate::types::TrajectoryState)>,
 }
 
 #[derive(Debug, Clone)]
@@ -241,6 +244,8 @@ pub(crate) struct FlushJob {
     /// git HEAD SHA after the commit that landed during this turn, if any.
     /// Sparse: only set when `commit_mentioned` triggered a flush and HEAD moved.
     pub(crate) commit_sha: Option<String>,
+    /// Governor channels snapshot for TurnEval construction in the background worker.
+    pub(crate) turn_eval_channels: Option<(crate::types::SymptomChannels, f32, crate::types::TrajectoryState)>,
 }
 
 struct WorkspaceBuffer {
@@ -264,6 +269,9 @@ struct WorkspaceBuffer {
     workspace_root: std::path::PathBuf,
     /// git HEAD SHA captured when this buffer was first opened (start of chunk).
     head_sha_at_open: Option<String>,
+    /// Governor channels for the most recent turn ingested into this buffer.
+    /// Carried into FlushJob so the background worker can build TurnEval.
+    last_turn_eval_channels: Option<(crate::types::SymptomChannels, f32, crate::types::TrajectoryState)>,
 }
 
 impl WorkspaceBuffer {
@@ -286,6 +294,7 @@ impl WorkspaceBuffer {
             last_decision: None,
             workspace_root,
             head_sha_at_open,
+            last_turn_eval_channels: None,
         }
     }
 }
@@ -348,6 +357,9 @@ impl WorkspaceChunker {
                 buf.last_source_ts_ms = item.source_ts_ms;
             }
             buf.saw_commit |= item.commit_mentioned;
+            if item.turn_eval_channels.is_some() {
+                buf.last_turn_eval_channels = item.turn_eval_channels;
+            }
 
             buf.total_chars = buf.total_chars.saturating_add(item.exchange_text.len());
             buf.turns.push(item.exchange_text);
@@ -486,6 +498,7 @@ fn build_flush_job(workspace_id: String, buf: &mut WorkspaceBuffer) -> FlushJob 
         prior_decision: buf.last_decision.clone(),
         head_sha,
         commit_sha,
+        turn_eval_channels: buf.last_turn_eval_channels.take(),
     }
 }
 
@@ -656,6 +669,7 @@ pub(crate) async fn process_flush_jobs_serve(rx: AsyncReceiver<FlushJob>, state:
             user_emotion.as_ref(),
             assistant_emotion.as_ref(),
             &capsule,
+            &crate::types::TurnEval::default(),
         );
 
         if let Ok(db) = state.db_for(&job.workspace_id).await {
@@ -669,6 +683,7 @@ pub(crate) async fn process_flush_jobs_serve(rx: AsyncReceiver<FlushJob>, state:
                 user_emotion.as_ref(),
                 assistant_emotion.as_ref(),
                 &capsule,
+                &crate::types::TurnEval::default(),
                 job.prior_decision.as_deref(),
                 job.head_sha.as_deref(),
                 job.commit_sha.as_deref(),
@@ -786,6 +801,7 @@ pub(crate) async fn process_flush_jobs_proxy(
             user_emotion.as_ref(),
             assistant_emotion.as_ref(),
             &capsule,
+            &crate::types::TurnEval::default(),
         );
         let _ = crate::storage::insert_capsule_row(
             &db,
@@ -797,6 +813,7 @@ pub(crate) async fn process_flush_jobs_proxy(
             user_emotion.as_ref(),
             assistant_emotion.as_ref(),
             &capsule,
+            &crate::types::TurnEval::default(),
             job.prior_decision.as_deref(),
             job.head_sha.as_deref(),
             job.commit_sha.as_deref(),
@@ -899,6 +916,8 @@ pub(crate) async fn analysis_worker_multiplex(
             source_ts_ms: None,
             // Proxy mode doesn't have the workspace root readily available.
             workspace_root: std::path::PathBuf::new(),
+            // Proxy mode doesn't run the governor; no channels available.
+            turn_eval_channels: None,
         };
         chunker.ingest(meta.workspace_id.clone(), item).await;
     }
@@ -997,6 +1016,7 @@ pub(crate) async fn analysis_worker(
             grounding_note: None,
             source_ts_ms: None,
             workspace_root: std::path::PathBuf::new(),
+            turn_eval_channels: None,
         };
         chunker.ingest(meta.workspace_id.clone(), item).await;
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -83,6 +83,28 @@ fn capsules_schema() -> Arc<Schema> {
         Field::new("head_sha", DataType::Utf8, true),
         // Git provenance: SHA of the commit that landed during this turn (sparse).
         Field::new("commit_sha", DataType::Utf8, true),
+        // TurnEval: agent tuning (diagnose) dimensions — persisted governor SymptomChannels.
+        Field::new("te_repetition", DataType::Float32, true),
+        Field::new("te_novelty_collapse", DataType::Float32, true),
+        Field::new("te_semantic_stall", DataType::Float32, true),
+        Field::new("te_effort_spike", DataType::Float32, true),
+        Field::new("te_alignment_debt", DataType::Float32, true),
+        Field::new("te_path_hallucination", DataType::Float32, true),
+        Field::new("te_grounding_stall", DataType::Float32, true),
+        Field::new("te_instruction_staticness", DataType::Float32, true),
+        Field::new("te_logic_churn", DataType::Float32, true),
+        Field::new("te_fluency", DataType::Float32, true),
+        Field::new("te_trajectory_intensity", DataType::Float32, true),
+        Field::new("te_trajectory_state", DataType::Utf8, true),
+        // TurnEval: developer coaching (coach) dimensions.
+        Field::new("te_clarity", DataType::Float32, true),
+        Field::new("te_context_freshness", DataType::Float32, true),
+        Field::new("te_verification_rigor", DataType::Float32, true),
+        Field::new("te_decision_progress", DataType::Float32, true),
+        Field::new("te_scope_discipline", DataType::Float32, true),
+        // TurnEval: flags (comma-joined) and outcome hint.
+        Field::new("te_flags", DataType::Utf8, true),
+        Field::new("te_outcome_hint", DataType::Utf8, true),
     ]))
 }
 
@@ -122,6 +144,31 @@ pub(crate) async fn ensure_capsules_table(db: &Connection) -> anyhow::Result<lan
                 add_str("questions_text", &mut exprs);
                 add_str("head_sha", &mut exprs);
                 add_str("commit_sha", &mut exprs);
+                // TurnEval columns (added in v0.13)
+                let add_f32 = |name: &str, exprs: &mut Vec<(String, String)>| {
+                    if !existing.contains(name) {
+                        exprs.push((name.to_string(), "CAST(NULL AS FLOAT)".to_string()));
+                    }
+                };
+                add_f32("te_repetition", &mut exprs);
+                add_f32("te_novelty_collapse", &mut exprs);
+                add_f32("te_semantic_stall", &mut exprs);
+                add_f32("te_effort_spike", &mut exprs);
+                add_f32("te_alignment_debt", &mut exprs);
+                add_f32("te_path_hallucination", &mut exprs);
+                add_f32("te_grounding_stall", &mut exprs);
+                add_f32("te_instruction_staticness", &mut exprs);
+                add_f32("te_logic_churn", &mut exprs);
+                add_f32("te_fluency", &mut exprs);
+                add_f32("te_trajectory_intensity", &mut exprs);
+                add_str("te_trajectory_state", &mut exprs);
+                add_f32("te_clarity", &mut exprs);
+                add_f32("te_context_freshness", &mut exprs);
+                add_f32("te_verification_rigor", &mut exprs);
+                add_f32("te_decision_progress", &mut exprs);
+                add_f32("te_scope_discipline", &mut exprs);
+                add_str("te_flags", &mut exprs);
+                add_str("te_outcome_hint", &mut exprs);
 
                 if !exprs.is_empty() {
                     let _ = t
@@ -203,6 +250,32 @@ pub(crate) async fn ensure_capsules_table(db: &Connection) -> anyhow::Result<lan
                 Arc::new(StringArray::from_iter(std::iter::empty::<Option<&str>>()));
             let commit_sha =
                 Arc::new(StringArray::from_iter(std::iter::empty::<Option<&str>>()));
+            // TurnEval columns
+            let te_f32_empty = || -> Arc<dyn arrow_array::Array> {
+                Arc::new(Float32Array::from_iter(std::iter::empty::<Option<f32>>()))
+            };
+            let te_str_empty = || -> Arc<dyn arrow_array::Array> {
+                Arc::new(StringArray::from_iter(std::iter::empty::<Option<&str>>()))
+            };
+            let te_repetition = te_f32_empty();
+            let te_novelty_collapse = te_f32_empty();
+            let te_semantic_stall = te_f32_empty();
+            let te_effort_spike = te_f32_empty();
+            let te_alignment_debt = te_f32_empty();
+            let te_path_hallucination = te_f32_empty();
+            let te_grounding_stall = te_f32_empty();
+            let te_instruction_staticness = te_f32_empty();
+            let te_logic_churn = te_f32_empty();
+            let te_fluency = te_f32_empty();
+            let te_trajectory_intensity = te_f32_empty();
+            let te_trajectory_state = te_str_empty();
+            let te_clarity = te_f32_empty();
+            let te_context_freshness = te_f32_empty();
+            let te_verification_rigor = te_f32_empty();
+            let te_decision_progress = te_f32_empty();
+            let te_scope_discipline = te_f32_empty();
+            let te_flags = te_str_empty();
+            let te_outcome_hint = te_str_empty();
 
             let batch = RecordBatch::try_new(
                 schema.clone(),
@@ -242,6 +315,25 @@ pub(crate) async fn ensure_capsules_table(db: &Connection) -> anyhow::Result<lan
                     questions_text,
                     head_sha,
                     commit_sha,
+                    te_repetition,
+                    te_novelty_collapse,
+                    te_semantic_stall,
+                    te_effort_spike,
+                    te_alignment_debt,
+                    te_path_hallucination,
+                    te_grounding_stall,
+                    te_instruction_staticness,
+                    te_logic_churn,
+                    te_fluency,
+                    te_trajectory_intensity,
+                    te_trajectory_state,
+                    te_clarity,
+                    te_context_freshness,
+                    te_verification_rigor,
+                    te_decision_progress,
+                    te_scope_discipline,
+                    te_flags,
+                    te_outcome_hint,
                 ],
             )
             .context("failed to build empty schema batch")?;
@@ -382,6 +474,26 @@ pub(crate) fn record_batches_to_hits(
             idx("symbols").and_then(|i| batch.column(i).as_any().downcast_ref::<ListArray>());
         let head_sha_col = col_str("head_sha");
         let commit_sha_col = col_str("commit_sha");
+        // TurnEval column accessors (nullable — backward compat with old capsules)
+        let te_repetition_col = col_f32("te_repetition");
+        let te_novelty_collapse_col = col_f32("te_novelty_collapse");
+        let te_semantic_stall_col = col_f32("te_semantic_stall");
+        let te_effort_spike_col = col_f32("te_effort_spike");
+        let te_alignment_debt_col = col_f32("te_alignment_debt");
+        let te_path_hallucination_col = col_f32("te_path_hallucination");
+        let te_grounding_stall_col = col_f32("te_grounding_stall");
+        let te_instruction_staticness_col = col_f32("te_instruction_staticness");
+        let te_logic_churn_col = col_f32("te_logic_churn");
+        let te_fluency_col = col_f32("te_fluency");
+        let te_trajectory_intensity_col = col_f32("te_trajectory_intensity");
+        let te_trajectory_state_col = col_str("te_trajectory_state");
+        let te_clarity_col = col_f32("te_clarity");
+        let te_context_freshness_col = col_f32("te_context_freshness");
+        let te_verification_rigor_col = col_f32("te_verification_rigor");
+        let te_decision_progress_col = col_f32("te_decision_progress");
+        let te_scope_discipline_col = col_f32("te_scope_discipline");
+        let te_flags_col = col_str("te_flags");
+        let te_outcome_hint_col = col_str("te_outcome_hint");
 
         for row in 0..batch.num_rows() {
             if out.len() >= limit {
@@ -511,6 +623,63 @@ pub(crate) fn record_batches_to_hits(
             let commit_sha = commit_sha_col
                 .and_then(|a| (!a.is_null(row)).then(|| a.value(row).to_string()));
 
+            // Read TurnEval fields (best-effort — all nullable for backward compat).
+            let read_te_f32 = |col: Option<&Float32Array>| -> f32 {
+                col.and_then(|a| (!a.is_null(row)).then(|| a.value(row)))
+                    .unwrap_or(0.0)
+            };
+            let te_traj_state = te_trajectory_state_col
+                .and_then(|a| (!a.is_null(row)).then(|| a.value(row)))
+                .map(|s| match s {
+                    "watch" => crate::types::TrajectoryState::Watch,
+                    "intervene" => crate::types::TrajectoryState::Intervene,
+                    _ => crate::types::TrajectoryState::Stable,
+                })
+                .unwrap_or_default();
+            let te_flags_raw = te_flags_col
+                .and_then(|a| (!a.is_null(row)).then(|| a.value(row).to_string()))
+                .unwrap_or_default();
+            let te_flags: Vec<String> = te_flags_raw
+                .split(',')
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .collect();
+            let te_outcome_hint = te_outcome_hint_col
+                .and_then(|a| (!a.is_null(row)).then(|| a.value(row).to_string()))
+                .unwrap_or_default();
+
+            // Only materialise TurnEval if we have at least one non-default value.
+            let turn_eval = if read_te_f32(te_trajectory_intensity_col) > 0.0
+                || read_te_f32(te_clarity_col) > 0.0
+                || !te_flags.is_empty()
+            {
+                Some(crate::types::TurnEval {
+                    version: "v1".to_string(),
+                    repetition: read_te_f32(te_repetition_col),
+                    novelty_collapse: read_te_f32(te_novelty_collapse_col),
+                    semantic_stall: read_te_f32(te_semantic_stall_col),
+                    effort_spike: read_te_f32(te_effort_spike_col),
+                    alignment_debt: read_te_f32(te_alignment_debt_col),
+                    path_hallucination: read_te_f32(te_path_hallucination_col),
+                    grounding_stall: read_te_f32(te_grounding_stall_col),
+                    instruction_staticness: read_te_f32(te_instruction_staticness_col),
+                    logic_churn: read_te_f32(te_logic_churn_col),
+                    fluency: read_te_f32(te_fluency_col),
+                    trajectory_intensity: read_te_f32(te_trajectory_intensity_col),
+                    trajectory_state: te_traj_state,
+                    clarity: read_te_f32(te_clarity_col),
+                    context_freshness: read_te_f32(te_context_freshness_col),
+                    verification_rigor: read_te_f32(te_verification_rigor_col),
+                    decision_progress: read_te_f32(te_decision_progress_col),
+                    scope_discipline: read_te_f32(te_scope_discipline_col),
+                    flags: te_flags,
+                    outcome_hint: te_outcome_hint,
+                    evidence: vec![],
+                })
+            } else {
+                None
+            };
+
             let cap = crate::types::IntentCapsule {
                 category: cat.to_string(),
                 intent: int_text,
@@ -544,6 +713,7 @@ pub(crate) fn record_batches_to_hits(
                 assistant_emotion,
                 head_sha,
                 commit_sha,
+                turn_eval,
             });
         }
     }
@@ -932,6 +1102,7 @@ pub(crate) async fn query_capsules_lancedb(
                     .and_then(|a| (!a.is_null(row)).then(|| a.value(row).to_string())),
                 commit_sha: commit_sha_col
                     .and_then(|a| (!a.is_null(row)).then(|| a.value(row).to_string())),
+                turn_eval: None,
             });
         }
     }
@@ -1372,6 +1543,7 @@ async fn scan_capsules_lancedb_impl(
                     .and_then(|a| (!a.is_null(row)).then(|| a.value(row).to_string())),
                 commit_sha: commit_sha_col
                     .and_then(|a| (!a.is_null(row)).then(|| a.value(row).to_string())),
+                turn_eval: None,
             });
         }
     }
@@ -1718,10 +1890,30 @@ pub(crate) async fn trace_capsules_lancedb(
                 .and_then(|i| batch.column(i).as_any().downcast_ref::<ListArray>());
             let symbols_col =
                 idx("symbols").and_then(|i| batch.column(i).as_any().downcast_ref::<ListArray>());
-            let head_sha_col = col_str("head_sha");
-            let commit_sha_col = col_str("commit_sha");
+        let head_sha_col = col_str("head_sha");
+        let commit_sha_col = col_str("commit_sha");
+        // TurnEval columns — declared for future use when this scan path surfaces turn_eval.
+        let _te_repetition_col = col_f32("te_repetition");
+        let _te_novelty_collapse_col = col_f32("te_novelty_collapse");
+        let _te_semantic_stall_col = col_f32("te_semantic_stall");
+        let _te_effort_spike_col = col_f32("te_effort_spike");
+        let _te_alignment_debt_col = col_f32("te_alignment_debt");
+        let _te_path_hallucination_col = col_f32("te_path_hallucination");
+        let _te_grounding_stall_col = col_f32("te_grounding_stall");
+        let _te_instruction_staticness_col = col_f32("te_instruction_staticness");
+        let _te_logic_churn_col = col_f32("te_logic_churn");
+        let _te_fluency_col = col_f32("te_fluency");
+        let _te_trajectory_intensity_col = col_f32("te_trajectory_intensity");
+        let _te_trajectory_state_col = col_str("te_trajectory_state");
+        let _te_clarity_col = col_f32("te_clarity");
+        let _te_context_freshness_col = col_f32("te_context_freshness");
+        let _te_verification_rigor_col = col_f32("te_verification_rigor");
+        let _te_decision_progress_col = col_f32("te_decision_progress");
+        let _te_scope_discipline_col = col_f32("te_scope_discipline");
+        let _te_flags_col = col_str("te_flags");
+        let _te_outcome_hint_col = col_str("te_outcome_hint");
 
-            for row in 0..batch.num_rows() {
+        for row in 0..batch.num_rows() {
                 let id = match id_col.and_then(|a| (!a.is_null(row)).then(|| a.value(row))) {
                     Some(v) if !v.is_empty() => v.to_string(),
                     _ => continue,
@@ -1889,6 +2081,7 @@ pub(crate) async fn trace_capsules_lancedb(
                             .and_then(|a| (!a.is_null(row)).then(|| a.value(row).to_string())),
                         commit_sha: commit_sha_col
                             .and_then(|a| (!a.is_null(row)).then(|| a.value(row).to_string())),
+                        turn_eval: None,
                     },
                 );
 
@@ -1916,6 +2109,8 @@ pub(crate) async fn insert_capsule_row(
     user_emotion: Option<&crate::emotion::EmotionMeta>,
     assistant_emotion: Option<&crate::emotion::EmotionMeta>,
     capsule: &crate::IntentCapsule,
+    // Turn-level evaluation metadata (diagnose + coach dimensions).
+    turn_eval: &crate::types::TurnEval,
     // Prior decision text from the preceding capsule in the same session/sequence.
     // Encodes causal continuity into the embedding so work threads cluster in vector space.
     prior_decision: Option<&str>,
@@ -2042,6 +2237,46 @@ pub(crate) async fn insert_capsule_row(
     let head_sha_arr = Arc::new(StringArray::from(vec![head_sha]));
     let commit_sha_arr = Arc::new(StringArray::from(vec![commit_sha]));
 
+    // TurnEval arrays
+    let te_traj_state_str = match turn_eval.trajectory_state {
+        crate::types::TrajectoryState::Stable => "stable",
+        crate::types::TrajectoryState::Watch => "watch",
+        crate::types::TrajectoryState::Intervene => "intervene",
+    };
+    let te_flags_str = if turn_eval.flags.is_empty() {
+        None
+    } else {
+        Some(turn_eval.flags.join(","))
+    };
+    let te_outcome_str = if turn_eval.outcome_hint.is_empty() {
+        None
+    } else {
+        Some(turn_eval.outcome_hint.as_str())
+    };
+
+    let te_f32 = |v: f32| -> Arc<dyn arrow_array::Array> {
+        Arc::new(Float32Array::from(vec![Some(v)]))
+    };
+    let te_repetition_arr = te_f32(turn_eval.repetition);
+    let te_novelty_collapse_arr = te_f32(turn_eval.novelty_collapse);
+    let te_semantic_stall_arr = te_f32(turn_eval.semantic_stall);
+    let te_effort_spike_arr = te_f32(turn_eval.effort_spike);
+    let te_alignment_debt_arr = te_f32(turn_eval.alignment_debt);
+    let te_path_hallucination_arr = te_f32(turn_eval.path_hallucination);
+    let te_grounding_stall_arr = te_f32(turn_eval.grounding_stall);
+    let te_instruction_staticness_arr = te_f32(turn_eval.instruction_staticness);
+    let te_logic_churn_arr = te_f32(turn_eval.logic_churn);
+    let te_fluency_arr = te_f32(turn_eval.fluency);
+    let te_trajectory_intensity_arr = te_f32(turn_eval.trajectory_intensity);
+    let te_trajectory_state_arr = Arc::new(StringArray::from(vec![Some(te_traj_state_str)]));
+    let te_clarity_arr = te_f32(turn_eval.clarity);
+    let te_context_freshness_arr = te_f32(turn_eval.context_freshness);
+    let te_verification_rigor_arr = te_f32(turn_eval.verification_rigor);
+    let te_decision_progress_arr = te_f32(turn_eval.decision_progress);
+    let te_scope_discipline_arr = te_f32(turn_eval.scope_discipline);
+    let te_flags_arr = Arc::new(StringArray::from(vec![te_flags_str.as_deref()]));
+    let te_outcome_hint_arr = Arc::new(StringArray::from(vec![te_outcome_str]));
+
     let batch = RecordBatch::try_new(
         schema.clone(),
         vec![
@@ -2080,6 +2315,25 @@ pub(crate) async fn insert_capsule_row(
             questions_text_arr,
             head_sha_arr,
             commit_sha_arr,
+            te_repetition_arr,
+            te_novelty_collapse_arr,
+            te_semantic_stall_arr,
+            te_effort_spike_arr,
+            te_alignment_debt_arr,
+            te_path_hallucination_arr,
+            te_grounding_stall_arr,
+            te_instruction_staticness_arr,
+            te_logic_churn_arr,
+            te_fluency_arr,
+            te_trajectory_intensity_arr,
+            te_trajectory_state_arr,
+            te_clarity_arr,
+            te_context_freshness_arr,
+            te_verification_rigor_arr,
+            te_decision_progress_arr,
+            te_scope_discipline_arr,
+            te_flags_arr,
+            te_outcome_hint_arr,
         ],
     )
     .context("failed to build insert batch")?;
@@ -2298,6 +2552,26 @@ pub(crate) async fn insert_capsule_batch(
                     .map(|o| o.as_deref())
                     .collect::<Vec<_>>(),
             )),
+            // TurnEval columns: all null for replayed/reindexed rows (no live governor data).
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(StringArray::from(null_str.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(Float32Array::from(null_f32.clone())),
+            Arc::new(StringArray::from(null_str.clone())),
+            Arc::new(StringArray::from(null_str.clone())),
         ],
     )
     .context("failed to build batch insert RecordBatch")?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -155,6 +155,101 @@ pub struct IntentCapsule {
     pub questions: Vec<String>,
 }
 
+/// Turn-level evaluation metadata, computed on-the-fly during flush with zero LLM calls.
+///
+/// Combines:
+/// - **Agent tuning (diagnose)**: persisted governor SymptomChannels (already computed,
+///   previously discarded after friction decisions).
+/// - **Developer coaching (coach)**: heuristic scores about request quality, session health,
+///   verification discipline, and scope management.
+///
+/// Designed to power `unlost reflect` later — the LLM at reflect-time reconstructs
+/// the story from this structured telemetry only.
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+pub struct TurnEval {
+    /// Schema version — always "v1" for this generation.
+    #[serde(default)]
+    pub version: String,
+
+    // ── Agent tuning (diagnose) ──────────────────────────────────────────────
+    /// EMA-smoothed governor channel: symbol/topic repetition without progress.
+    #[serde(default)]
+    pub repetition: f32,
+    /// EMA-smoothed governor channel: novelty collapse (agent running out of new approaches).
+    #[serde(default)]
+    pub novelty_collapse: f32,
+    /// EMA-smoothed governor channel: semantic stall (conversation going in circles).
+    #[serde(default)]
+    pub semantic_stall: f32,
+    /// EMA-smoothed governor channel: effort spike (agent doing far more than asked).
+    #[serde(default)]
+    pub effort_spike: f32,
+    /// EMA-smoothed governor channel: alignment debt (repeated user corrections).
+    #[serde(default)]
+    pub alignment_debt: f32,
+    /// EMA-smoothed governor channel: path hallucination (referencing non-existent files).
+    #[serde(default)]
+    pub path_hallucination: f32,
+    /// EMA-smoothed governor channel: grounding stall (agent ignoring user-mentioned paths).
+    #[serde(default)]
+    pub grounding_stall: f32,
+    /// EMA-smoothed governor channel: instruction staticness (user repeating long instructions).
+    #[serde(default)]
+    pub instruction_staticness: f32,
+    /// EMA-smoothed governor channel: logic churn (rapid plan changes without progress).
+    #[serde(default)]
+    pub logic_churn: f32,
+    /// EMA-smoothed governor channel: fluency (high verbosity vs user input — blind acceptance).
+    #[serde(default)]
+    pub fluency: f32,
+    /// Composite trajectory instability intensity (0–1) at the time of this turn.
+    #[serde(default)]
+    pub trajectory_intensity: f32,
+    /// Trajectory controller state at the time of this turn.
+    #[serde(default)]
+    pub trajectory_state: TrajectoryState,
+
+    // ── Developer coaching (coach) ───────────────────────────────────────────
+    /// Was the user request specific enough? (0=vague, 1=precise)
+    /// Derived from: message length, symbol count, and subsequent correction rate.
+    #[serde(default)]
+    pub clarity: f32,
+    /// Is the session context still coherent / fresh? (0=stale/overloaded, 1=fresh)
+    /// Derived from: token cache-read ratio (compaction signal) and frustration slope.
+    /// Drops when context is being squeezed or the agent starts showing confusion.
+    #[serde(default)]
+    pub context_freshness: f32,
+    /// Were results verified after code changes? (0=unverified, 1=rigorously verified)
+    /// Derived from: presence of tool outcome strings (build/test pass/fail) in the exchange.
+    #[serde(default)]
+    pub verification_rigor: f32,
+    /// Did this turn move the task forward? (0=stalled/regressed, 1=clear progress)
+    /// Derived from: decision text change and symbol set evolution vs prior capsule.
+    #[serde(default)]
+    pub decision_progress: f32,
+    /// Did scope stay stable? (0=scope creep/drift, 1=focused)
+    /// Derived from: symbol set growth rate across recent history, category stability.
+    #[serde(default)]
+    pub scope_discipline: f32,
+
+    // ── Flags (both personas) ────────────────────────────────────────────────
+    /// Derived behavioral flags, e.g. "retry_loop", "session_heavy", "scope_shift",
+    /// "unverified_claim", "needs_clarification", "blind_acceptance".
+    #[serde(default)]
+    pub flags: Vec<String>,
+
+    // ── Outcome (placeholder — backfilled by delayed checkpoint pass in future) ──
+    /// Near-term outcome: "progressed" | "stalled" | "regressed" | "unclear"
+    #[serde(default)]
+    pub outcome_hint: String,
+
+    // ── Auditable evidence ────────────────────────────────────────────────────
+    /// Compact, auditable facts explaining why scores are what they are.
+    /// e.g. "no test/build outcome found after 3 code-touching turns"
+    #[serde(default)]
+    pub evidence: Vec<String>,
+}
+
 fn failure_mode_schema(_gen: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({
         "type": "string",
@@ -197,6 +292,8 @@ pub struct CapsuleHit {
     pub head_sha: Option<String>,
     /// git SHA of the commit that landed during this turn, if detected (sparse).
     pub commit_sha: Option<String>,
+    /// Turn-level evaluation metadata (coach + diagnose dimensions).
+    pub turn_eval: Option<TurnEval>,
 }
 
 #[cfg(test)]
@@ -415,6 +512,7 @@ mod tests {
             meta,
             head_sha: None,
             commit_sha: None,
+            turn_eval: None,
         };
 
         assert_eq!(hit.id, "test_id");


### PR DESCRIPTION
## Summary

- Adds `TurnEval` struct to every capsule: 12 agent-tuning dimensions (persisted governor `SymptomChannels`) + 5 developer coaching dimensions (`clarity`, `context_freshness`, `verification_rigor`, `decision_progress`, `scope_discipline`) + behavioral flags + outcome hint
- Wires the full pipeline: governor stash → `ChunkInput` → `FlushJob` → background worker builds `TurnEval` → LanceDB + JSONL + metrics
- `context_freshness` uses token cache-read ratio (compaction signal) + trajectory frustration slope rather than a static turn count
- All scoring is heuristic, zero LLM calls per turn; reflect-time LLM reconstructs the story from structured telemetry only
- Backward compatible: 19 new nullable `te_*` Lance columns added via schema evolution; existing installs auto-migrate

## Changelog

- **`TurnEval`**: Per-turn evaluation metadata computed on-the-fly at flush time with zero LLM calls. Each capsule now carries 12 agent-tuning (diagnose) dimensions — persisted governor `SymptomChannels` previously discarded after friction decisions — plus 5 developer coaching dimensions: `clarity`, `context_freshness` (cache ratio + frustration slope, captures compaction signal), `verification_rigor`, `decision_progress`, and `scope_discipline`. Behavioral flags (`session_heavy`, `session_too_long`, `retry_loop`, `blind_acceptance`, etc.) derived from thresholds on both dimensions. Stored in LanceDB, JSONL, and metrics. Displayed in `unlost inspect`. Foundation for `unlost reflect`.

Closes #20