### PR TITLE
feat: add Claude Cowork integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Claude Cowork integration**: New `unlost shim cowork` hook shim, `unlost shim replay cowork` backfill command, `unlost config agent cowork` installer, and `agents/cowork/` plugin package. Cowork shares Claude Code's hook wire format and JSONL transcript schema, so the implementation reuses the same parsing pipeline. Installing the plugin gives Cowork friction detection (`UserPromptSubmit`) and automatic session recording (`Stop`), plus the unlost MCP connector for in-session memory queries.
+
 ## [0.15.0] - 2026-05-20
 
 ### Added

--- a/agents/README.md
+++ b/agents/README.md
@@ -13,3 +13,7 @@ Claude hooks integration. Configures `UserPromptSubmit` and `Stop` hooks that in
 ### OpenCode (`agents/opencode/`)
 
 OpenCode plugin integration. Configures `opencode.json` to load the unlost plugin, which runs `unlost shim opencode` over stdio.
+
+### Cowork (`agents/cowork/`)
+
+Claude Cowork plugin integration. A plugin package (hooks + MCP connector) installed via the Cowork plugin UI. Uses `UserPromptSubmit` and `Stop` hooks — the same transcript format as Claude Code — so the implementation shares the same parsing pipeline.

--- a/agents/cowork/.mcp.json
+++ b/agents/cowork/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "unlost": {
+      "type": "stdio",
+      "command": "unlost",
+      "args": ["mcp", "serve", "--allow-writes"]
+    }
+  }
+}

--- a/agents/cowork/README.md
+++ b/agents/cowork/README.md
@@ -1,0 +1,39 @@
+# Claude Cowork Integration
+
+Unlost integrates with Claude Cowork via hooks and an MCP connector.
+
+## What it does
+
+- **`UserPromptSubmit`** — friction check before each prompt; injects a warning via `additionalContext` if a contradicting past decision is detected.
+- **`Stop`** — reads the session transcript after each turn and records user ↔ assistant exchanges as capsules in the local workspace store.
+- **MCP connector** — registers `unlost mcp serve` so Cowork (and the AI inside it) can query memory via `unlost_recall`, `unlost_orient`, `unlost_challenge`, etc.
+
+## Setup
+
+```bash
+# Per-project (writes to <project>/.claude/plugins/unlost/)
+unlost config agent cowork --path .
+
+# Global (writes to ~/.config/claude/plugins/unlost/)
+unlost config agent cowork --global
+```
+
+Then in Cowork: **Customize → Plugins → install from file** and select the printed directory.
+
+Alternatively, point Cowork's marketplace at this repository and install the `unlost` plugin directly.
+
+## Backfill
+
+To replay an existing Cowork transcript:
+
+```bash
+unlost shim replay cowork --path . --transcript-path /path/to/session.jsonl
+```
+
+## Cursor state
+
+Progress is tracked per session:
+
+```
+~/.local/share/unlost/workspaces/<ws_id>/cowork/<session_id>.cursor
+```

--- a/agents/cowork/hooks/hooks.json
+++ b/agents/cowork/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "unlost shim cowork",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "unlost shim cowork",
+            "async": true,
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/agents/cowork/plugin.json
+++ b/agents/cowork/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "unlost",
+  "version": "1.0.0",
+  "description": "Unlost memory for Claude Cowork: friction detection and automatic session recording.",
+  "author": "unfault"
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -766,6 +766,17 @@ pub enum ShimCommand {
         embed_cache_dir: Option<String>,
     },
 
+    /// Run the Claude Cowork hooks shim (reads hook JSON from stdin)
+    Cowork {
+        /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
+        #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
+        embed_model: String,
+
+        /// Embedding cache directory (defaults to XDG data dir)
+        #[arg(long, env = "UNLOST_EMBED_CACHE_DIR")]
+        embed_cache_dir: Option<String>,
+    },
+
     /// Replay/backfill agent transcripts into unlost
     Replay {
         #[command(subcommand)]
@@ -876,6 +887,49 @@ pub enum ReplayCommand {
         #[arg(long, default_value_t = false)]
         git_grounding: bool,
     },
+
+    /// Replay a Claude Cowork transcript file into the current workspace
+    Cowork {
+        /// Workspace path (defaults to current directory)
+        #[arg(long, default_value = ".")]
+        path: String,
+
+        /// Cowork transcript .jsonl file or directory path
+        #[arg(long)]
+        transcript_path: String,
+
+        /// Session id (defaults to transcript filename stem)
+        #[arg(long)]
+        session_id: Option<String>,
+
+        /// Force replay from beginning
+        #[arg(long, default_value_t = true)]
+        from_start: bool,
+
+        /// Skip turns already replayed (best-effort)
+        #[arg(long, default_value_t = true)]
+        dedupe: bool,
+
+        /// Disable LLM extraction (fast, zero cost)
+        #[arg(long, default_value_t = false)]
+        no_extraction: bool,
+
+        /// Enable full LLM extraction for every turn (slow, expensive)
+        #[arg(long, default_value_t = false)]
+        full_extraction: bool,
+
+        /// Clear existing replay state before starting
+        #[arg(long, default_value_t = false)]
+        clear: bool,
+
+        /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
+        #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
+        embed_model: String,
+
+        /// Embedding cache directory (defaults to XDG data dir)
+        #[arg(long, env = "UNLOST_EMBED_CACHE_DIR")]
+        embed_cache_dir: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -927,6 +981,17 @@ pub enum AgentCommand {
         /// Workspace path (defaults to current directory; uses git toplevel)
         #[arg(long, default_value = ".")]
         path: String,
+    },
+
+    /// Configure Claude Cowork to use unlost (writes plugin package)
+    Cowork {
+        /// Workspace path (defaults to current directory; uses git toplevel)
+        #[arg(long, default_value = ".")]
+        path: String,
+
+        /// Write plugin to global plugin dir (~/.config/claude/plugins/) instead of per-project
+        #[arg(long)]
+        global: bool,
     },
 
     /// Configure any MCP-aware agent to use unlost via the MCP server

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -151,6 +151,10 @@ fn handle_agent_command(cmd: AgentCommand) -> anyhow::Result<()> {
             configure_copilot(&path)?;
         }
 
+        AgentCommand::Cowork { path, global } => {
+            configure_cowork(&path, global)?;
+        }
+
         AgentCommand::Mcp {
             target,
             path,
@@ -258,6 +262,102 @@ fn configure_claude(path: &str, global: bool) -> anyhow::Result<()> {
     println!("configured ({scope}): {}", cfg_path.display());
 
     write_claude_walkthrough_skill(&cfg_path)?;
+    Ok(())
+}
+
+/// Write the unlost plugin package for Claude Cowork.
+///
+/// Cowork uses a plugin directory (not a settings JSON like Claude Code).
+/// The plugin is written to:
+///   global:      ~/.config/claude/plugins/unlost/
+///   per-project: <project>/.claude/plugins/unlost/
+///
+/// The user loads it via Customize → Plugins → install from file in the Cowork UI.
+fn configure_cowork(path: &str, global: bool) -> anyhow::Result<()> {
+    let plugin_dir = if global {
+        let home = std::env::var("HOME")
+            .map(std::path::PathBuf::from)
+            .or_else(|_| std::env::var("USERPROFILE").map(std::path::PathBuf::from))
+            .map_err(|_| anyhow::anyhow!("could not determine home directory"))?;
+        home.join(".config").join("claude").join("plugins").join("unlost")
+    } else {
+        let root =
+            crate::workspace::git_toplevel(std::path::Path::new(path)).unwrap_or_else(|| {
+                crate::workspace::canonicalize_dir(std::path::Path::new(path))
+                    .unwrap_or_else(|_| std::path::PathBuf::from(path))
+            });
+        let root = crate::workspace::canonicalize_dir(&root)?;
+        root.join(".claude").join("plugins").join("unlost")
+    };
+
+    std::fs::create_dir_all(plugin_dir.join("hooks"))?;
+
+    // plugin.json — manifest
+    let plugin_json = serde_json::json!({
+        "name": "unlost",
+        "version": "1.0.0",
+        "description": "Unlost memory for Claude Cowork: friction detection and automatic session recording.",
+        "author": "unfault"
+    });
+    std::fs::write(
+        plugin_dir.join("plugin.json"),
+        serde_json::to_string_pretty(&plugin_json)?,
+    )?;
+
+    // hooks/hooks.json — UserPromptSubmit (friction) + Stop (record)
+    let hooks_json = serde_json::json!({
+        "hooks": {
+            "UserPromptSubmit": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "unlost shim cowork",
+                            "timeout": 10
+                        }
+                    ]
+                }
+            ],
+            "Stop": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "unlost shim cowork",
+                            "async": true,
+                            "timeout": 60
+                        }
+                    ]
+                }
+            ]
+        }
+    });
+    std::fs::write(
+        plugin_dir.join("hooks").join("hooks.json"),
+        serde_json::to_string_pretty(&hooks_json)?,
+    )?;
+
+    // .mcp.json — registers unlost MCP server as a connector
+    let mcp_json = serde_json::json!({
+        "mcpServers": {
+            "unlost": {
+                "type": "stdio",
+                "command": "unlost",
+                "args": ["mcp", "serve", "--allow-writes"]
+            }
+        }
+    });
+    std::fs::write(
+        plugin_dir.join(".mcp.json"),
+        serde_json::to_string_pretty(&mcp_json)?,
+    )?;
+
+    let scope = if global { "global" } else { "project" };
+    println!("configured ({scope}): {}", plugin_dir.display());
+    println!();
+    println!("Next: open Cowork → Customize → Plugins → install from file");
+    println!("      and select: {}", plugin_dir.display());
+
     Ok(())
 }
 

--- a/src/companion/flow.rs
+++ b/src/companion/flow.rs
@@ -32,6 +32,7 @@ pub(crate) enum AgentKind {
     OpenCode,
     Claude,
     Copilot,
+    Cowork,
 }
 
 impl AgentKind {
@@ -41,6 +42,7 @@ impl AgentKind {
             AgentKind::OpenCode => "opencode",
             AgentKind::Claude => "claude",
             AgentKind::Copilot => "copilot",
+            AgentKind::Cowork => "cowork",
         }
     }
 }

--- a/src/companion/shims/cowork.rs
+++ b/src/companion/shims/cowork.rs
@@ -1,0 +1,1030 @@
+//! Claude Cowork hooks shim.
+//!
+//! Invoked by Cowork hooks (UserPromptSubmit, Stop) via stdin JSON.
+//! The wire protocol is identical to Claude Code hooks — same field names,
+//! same transcript JSONL format — so this file is a thin re-skin of
+//! `claude.rs` with Cowork-specific cursor paths and source pointers.
+//!
+//! Hook events handled:
+//!   UserPromptSubmit — friction check; returns additionalContext if needed.
+//!   Stop             — parse transcript, record new turns. Run with async:true.
+
+use crate::companion::flow::{
+    AgentKind, CheckEvent, Flow, FlowConfig, RecordTurnEvent, UsageEvent,
+};
+use crate::workspace::get_or_create_workspace_paths;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::io::{BufRead, Read, Write};
+use std::path::{Path, PathBuf};
+
+// ============================================================================
+// Wire protocol (identical to Claude Code)
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+struct HookInput {
+    hook_event_name: String,
+    session_id: String,
+    cwd: String,
+    #[serde(default)]
+    transcript_path: Option<String>,
+    #[serde(default)]
+    prompt: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct HookOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "hookSpecificOutput")]
+    hook_specific_output: Option<HookSpecificOutput>,
+}
+
+#[derive(Debug, Serialize)]
+struct HookSpecificOutput {
+    #[serde(rename = "hookEventName")]
+    hook_event_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "additionalContext")]
+    additional_context: Option<String>,
+}
+
+// ============================================================================
+// Transcript types (same JSONL schema as Claude Code)
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+struct TranscriptLine {
+    #[serde(rename = "type")]
+    line_type: Option<String>,
+    #[serde(rename = "isSidechain")]
+    is_sidechain: Option<bool>,
+    uuid: Option<String>,
+    message: Option<TranscriptMessage>,
+    #[serde(flatten)]
+    extra: std::collections::HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptMessage {
+    role: Option<String>,
+    content: Option<serde_json::Value>,
+    model: Option<String>,
+    usage: Option<TranscriptUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptUsage {
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+    cache_read_input_tokens: Option<i64>,
+    cache_creation_input_tokens: Option<i64>,
+}
+
+// ============================================================================
+// Cursor state
+// ============================================================================
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct CursorState {
+    byte_offset: u64,
+    last_uuid: Option<String>,
+}
+
+fn cursor_path(workspace_id: &str, session_id: &str) -> PathBuf {
+    crate::workspace::unlost_workspace_dir(workspace_id)
+        .join("cowork")
+        .join(format!("{}.cursor", session_id))
+}
+
+fn load_cursor(workspace_id: &str, session_id: &str) -> CursorState {
+    let path = cursor_path(workspace_id, session_id);
+    if let Ok(data) = std::fs::read_to_string(&path) {
+        return serde_json::from_str(&data).unwrap_or_default();
+    }
+    CursorState::default()
+}
+
+fn save_cursor(workspace_id: &str, session_id: &str, cursor: &CursorState) {
+    let path = cursor_path(workspace_id, session_id);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(data) = serde_json::to_string(cursor) {
+        let _ = std::fs::write(&path, data);
+    }
+}
+
+fn turnkeys_path(workspace_id: &str, session_id: &str) -> PathBuf {
+    crate::workspace::unlost_workspace_dir(workspace_id)
+        .join("cowork")
+        .join(format!("{}.turnkeys", session_id))
+}
+
+fn load_turnkeys(workspace_id: &str, session_id: &str) -> HashSet<String> {
+    let path = turnkeys_path(workspace_id, session_id);
+    match std::fs::read_to_string(&path) {
+        Ok(s) => s
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect(),
+        Err(_) => HashSet::new(),
+    }
+}
+
+fn append_turnkeys(workspace_id: &str, session_id: &str, keys: &[String]) {
+    if keys.is_empty() {
+        return;
+    }
+    let path = turnkeys_path(workspace_id, session_id);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let mut f = match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+    for k in keys {
+        if k.trim().is_empty() {
+            continue;
+        }
+        let _ = writeln!(f, "{}", k.trim());
+    }
+}
+
+// ============================================================================
+// Transcript parsing (shared helpers, mirrored from claude.rs)
+// ============================================================================
+
+struct ParsedTurn {
+    user_text: String,
+    assistant_text: String,
+    usage: Option<UsageEvent>,
+    touched_paths: Vec<String>,
+    user_uuid: Option<String>,
+    assistant_uuid: Option<String>,
+    timestamp_ms: i64,
+}
+
+fn turn_key(turn: &ParsedTurn) -> Option<String> {
+    let u = turn.user_uuid.as_deref()?.trim();
+    if u.is_empty() {
+        return None;
+    }
+    let a = turn.assistant_uuid.as_deref().unwrap_or("").trim();
+    Some(format!("{u}:{a}"))
+}
+
+fn build_source_pointer(transcript_path: &Path, turn: &ParsedTurn) -> Option<String> {
+    let path_str = transcript_path.to_str()?;
+    if path_str.is_empty() {
+        return None;
+    }
+    let uuid = turn
+        .user_uuid
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    match uuid {
+        Some(u) => Some(format!("cowork+jsonl://{path_str}#turn={u}")),
+        None => Some(format!("cowork+jsonl://{path_str}")),
+    }
+}
+
+fn truncate(mut s: String, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    s.truncate(max_bytes);
+    s.push_str("\n...(truncated)");
+    s
+}
+
+fn value_to_compact_text(v: &serde_json::Value, max_bytes: usize) -> String {
+    match v {
+        serde_json::Value::String(s) => truncate(s.clone(), max_bytes),
+        serde_json::Value::Array(a) => {
+            let mut out = String::new();
+            for item in a {
+                if let Some(obj) = item.as_object() {
+                    if obj.get("type").and_then(|t| t.as_str()) == Some("text") {
+                        if let Some(t) = obj.get("text").and_then(|t| t.as_str()) {
+                            if !out.is_empty() {
+                                out.push('\n');
+                            }
+                            out.push_str(t);
+                        }
+                    }
+                }
+            }
+            if out.trim().is_empty() {
+                truncate(v.to_string(), max_bytes)
+            } else {
+                truncate(out, max_bytes)
+            }
+        }
+        _ => truncate(v.to_string(), max_bytes),
+    }
+}
+
+fn extract_tool_result_text(content: &serde_json::Value) -> Option<String> {
+    let serde_json::Value::Array(blocks) = content else {
+        return None;
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for block in blocks {
+        let Some(obj) = block.as_object() else {
+            continue;
+        };
+        if obj.get("type").and_then(|t| t.as_str()) != Some("tool_result") {
+            continue;
+        }
+        let is_error = obj
+            .get("is_error")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let tool_use_id = obj
+            .get("tool_use_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let text = value_to_compact_text(
+            obj.get("content").unwrap_or(&serde_json::Value::Null),
+            12 * 1024,
+        );
+        if text.trim().is_empty() {
+            continue;
+        }
+        let mut s = if is_error {
+            "Tool result (error)".to_string()
+        } else {
+            "Tool result".to_string()
+        };
+        if !tool_use_id.is_empty() {
+            s.push(' ');
+            s.push_str(tool_use_id);
+        }
+        s.push_str(":\n");
+        s.push_str(text.trim());
+        parts.push(s);
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n\n"))
+    }
+}
+
+fn looks_like_path(s: &str) -> bool {
+    let s = s.trim();
+    !s.is_empty()
+        && s.len() <= 260
+        && !s.contains('\n')
+        && !s.contains('\r')
+        && !s.contains(' ')
+        && (s.contains('/') || s.contains('\\'))
+}
+
+fn normalize_path(p: &str, cwd: &Path) -> Option<String> {
+    let mut s = p.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let owned;
+    if s.contains('\\') {
+        owned = s.replace('\\', "/");
+        s = &owned;
+    }
+    let s = s.strip_prefix("./").unwrap_or(s);
+    if let Ok(abs) = std::path::Path::new(s).canonicalize() {
+        if let Ok(cwd_abs) = cwd.canonicalize() {
+            if let Ok(rel) = abs.strip_prefix(&cwd_abs) {
+                let rel = rel.to_string_lossy().replace('\\', "/");
+                let rel = rel.trim_start_matches('/').to_string();
+                if !rel.is_empty() {
+                    return Some(rel);
+                }
+            }
+        }
+    }
+    Some(s.trim_start_matches('/').to_string())
+}
+
+fn collect_paths(v: &serde_json::Value, cwd: &Path, out: &mut HashSet<String>) {
+    match v {
+        serde_json::Value::String(s) => {
+            if looks_like_path(s) {
+                if let Some(p) = normalize_path(s, cwd) {
+                    out.insert(p);
+                }
+            }
+        }
+        serde_json::Value::Array(a) => {
+            for x in a {
+                collect_paths(x, cwd, out);
+            }
+        }
+        serde_json::Value::Object(m) => {
+            for k in ["path", "file", "file_path", "filepath", "filename", "target", "target_file"] {
+                if let Some(val) = m.get(k) {
+                    collect_paths(val, cwd, out);
+                }
+            }
+            for val in m.values() {
+                collect_paths(val, cwd, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn paths_from_content(content: &serde_json::Value, cwd: &Path) -> Vec<String> {
+    let mut out: HashSet<String> = HashSet::new();
+    if let serde_json::Value::Array(blocks) = content {
+        for block in blocks {
+            if let Some(obj) = block.as_object() {
+                let ty = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                if ty == "tool_use" || ty == "tool_result" {
+                    for key in ["input", "result"] {
+                        if let Some(v) = obj.get(key) {
+                            collect_paths(v, cwd, &mut out);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let mut v: Vec<_> = out.into_iter().collect();
+    v.sort();
+    v.truncate(64);
+    v
+}
+
+fn extract_text(content: &serde_json::Value) -> String {
+    match content {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(blocks) => {
+            let mut texts = Vec::new();
+            for block in blocks {
+                if let Some(obj) = block.as_object() {
+                    if obj.get("type").and_then(|t| t.as_str()) == Some("text") {
+                        if let Some(text) = obj.get("text").and_then(|t| t.as_str()) {
+                            texts.push(text.to_string());
+                        }
+                    }
+                }
+            }
+            texts.join("\n")
+        }
+        _ => String::new(),
+    }
+}
+
+fn is_tool_result(content: &serde_json::Value) -> bool {
+    if let serde_json::Value::Array(blocks) = content {
+        for block in blocks {
+            if let Some(obj) = block.as_object() {
+                if obj.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn parse_transcript(
+    transcript_path: &Path,
+    cursor: &CursorState,
+    cwd: &Path,
+) -> anyhow::Result<(Vec<ParsedTurn>, CursorState)> {
+    let file = std::fs::File::open(transcript_path)?;
+    let file_size = file.metadata()?.len();
+    let start_offset = if cursor.byte_offset > file_size {
+        0
+    } else {
+        cursor.byte_offset
+    };
+
+    let mut reader = std::io::BufReader::new(file);
+    reader.seek_relative(start_offset as i64)?;
+
+    let mut turns = Vec::new();
+    let mut current_user_text: Option<String> = None;
+    let mut current_user_uuid: Option<String> = None;
+    let mut current_assistant_text = String::new();
+    let mut current_last_assistant_uuid: Option<String> = None;
+    let mut current_timestamp_ms = 0i64;
+    let mut pending_touched: HashSet<String> = HashSet::new();
+    let mut current_usage: Option<UsageEvent> = None;
+    let mut last_uuid: Option<String> = cursor.last_uuid.clone();
+    let mut new_offset = start_offset;
+    let mut seen_last_uuid = start_offset > 0 || cursor.last_uuid.is_none();
+
+    for line in reader.lines() {
+        let line = line?;
+        new_offset += line.len() as u64 + 1;
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let parsed: TranscriptLine = match serde_json::from_str(&line) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        if let Some(ts) = parsed.extra.get("time").and_then(|v| v.as_i64()) {
+            current_timestamp_ms = ts;
+        }
+        for val in parsed.extra.values() {
+            collect_paths(val, cwd, &mut pending_touched);
+        }
+
+        let line_type = match &parsed.line_type {
+            Some(t) => t.as_str(),
+            None => continue,
+        };
+
+        if line_type == "file-history-snapshot" {
+            for val in parsed.extra.values() {
+                collect_paths(val, cwd, &mut pending_touched);
+            }
+            if let Some(uuid) = &parsed.uuid {
+                last_uuid = Some(uuid.clone());
+            }
+            continue;
+        }
+
+        if parsed.is_sidechain == Some(true) {
+            continue;
+        }
+
+        if let Some(ref last) = cursor.last_uuid {
+            if !seen_last_uuid {
+                if parsed.uuid.as_ref() == Some(last) {
+                    seen_last_uuid = true;
+                }
+                continue;
+            }
+        }
+
+        let message = match &parsed.message {
+            Some(m) => m,
+            None => continue,
+        };
+        let role = match &message.role {
+            Some(r) => r.as_str(),
+            None => continue,
+        };
+        let content = match &message.content {
+            Some(c) => c,
+            None => continue,
+        };
+
+        for p in paths_from_content(content, cwd) {
+            pending_touched.insert(p);
+        }
+
+        match (line_type, role) {
+            ("user", "user") => {
+                if is_tool_result(content) {
+                    if current_user_text.is_some() {
+                        if let Some(tool_text) = extract_tool_result_text(content) {
+                            if !current_assistant_text.is_empty() {
+                                current_assistant_text.push_str("\n\n");
+                            }
+                            current_assistant_text.push_str(&tool_text);
+                        }
+                    }
+                    if let Some(uuid) = &parsed.uuid {
+                        last_uuid = Some(uuid.clone());
+                    }
+                    continue;
+                }
+
+                let text = extract_text(content);
+                if text.trim().is_empty() {
+                    continue;
+                }
+
+                if let Some(user_text) = current_user_text.take() {
+                    turns.push(ParsedTurn {
+                        user_text,
+                        assistant_text: std::mem::take(&mut current_assistant_text),
+                        usage: current_usage.take(),
+                        touched_paths: pending_touched.drain().collect(),
+                        user_uuid: current_user_uuid.take(),
+                        assistant_uuid: current_last_assistant_uuid.take(),
+                        timestamp_ms: current_timestamp_ms,
+                    });
+                }
+
+                current_user_text = Some(text);
+                current_user_uuid = parsed.uuid.clone();
+                current_assistant_text.clear();
+                current_last_assistant_uuid = None;
+                current_usage = None;
+            }
+            ("assistant", "assistant") => {
+                let text = extract_text(content);
+                if !text.trim().is_empty() {
+                    if !current_assistant_text.is_empty() {
+                        current_assistant_text.push('\n');
+                    }
+                    current_assistant_text.push_str(&text);
+                }
+                if parsed.uuid.is_some() {
+                    current_last_assistant_uuid = parsed.uuid.clone();
+                }
+                if let Some(usage) = &message.usage {
+                    current_usage = Some(UsageEvent {
+                        provider_id: Some("anthropic".to_string()),
+                        model_id: message.model.clone(),
+                        cost: None,
+                        tokens_input: usage.input_tokens,
+                        tokens_output: usage.output_tokens,
+                        tokens_reasoning: None,
+                        tokens_cache_read: usage.cache_read_input_tokens,
+                        tokens_cache_write: usage.cache_creation_input_tokens,
+                    });
+                }
+            }
+            _ => {}
+        }
+
+        if let Some(uuid) = &parsed.uuid {
+            last_uuid = Some(uuid.clone());
+        }
+    }
+
+    if let Some(user_text) = current_user_text {
+        turns.push(ParsedTurn {
+            user_text,
+            assistant_text: current_assistant_text,
+            usage: current_usage,
+            touched_paths: pending_touched.drain().collect(),
+            user_uuid: current_user_uuid,
+            assistant_uuid: current_last_assistant_uuid,
+            timestamp_ms: current_timestamp_ms,
+        });
+    }
+
+    Ok((
+        turns,
+        CursorState {
+            byte_offset: new_offset,
+            last_uuid,
+        },
+    ))
+}
+
+// ============================================================================
+// Hook handlers
+// ============================================================================
+
+async fn handle_user_prompt_submit(flow: &mut Flow, input: &HookInput) -> anyhow::Result<()> {
+    let prompt = match &input.prompt {
+        Some(p) => p,
+        None => {
+            tracing::warn!("cowork UserPromptSubmit missing prompt field");
+            return Ok(());
+        }
+    };
+
+    let result = flow
+        .check_turn(CheckEvent {
+            directory: input.cwd.clone(),
+            text: prompt.clone(),
+            agent_kind: AgentKind::Cowork,
+            agent_session_id: Some(input.session_id.clone()),
+        })
+        .await;
+
+    let output = if let Some(note) = result.note {
+        HookOutput {
+            hook_specific_output: Some(HookSpecificOutput {
+                hook_event_name: "UserPromptSubmit".to_string(),
+                additional_context: Some(note),
+            }),
+        }
+    } else {
+        HookOutput {
+            hook_specific_output: None,
+        }
+    };
+
+    println!("{}", serde_json::to_string(&output)?);
+    std::io::stdout().flush()?;
+    Ok(())
+}
+
+async fn handle_stop(
+    flow: &mut Flow,
+    input: &HookInput,
+    embed_model: &str,
+    embed_cache_dir: Option<&str>,
+) -> anyhow::Result<()> {
+    let transcript_path = match &input.transcript_path {
+        Some(p) => PathBuf::from(p),
+        None => {
+            tracing::warn!("cowork Stop hook missing transcript_path");
+            return Ok(());
+        }
+    };
+
+    if !transcript_path.exists() {
+        tracing::warn!(path = %transcript_path.display(), "cowork: transcript file not found");
+        return Ok(());
+    }
+
+    let cwd_path = Path::new(&input.cwd);
+    let ws = match get_or_create_workspace_paths(cwd_path) {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(error = %e, "cowork: failed to get workspace paths");
+            return Ok(());
+        }
+    };
+
+    let cursor = load_cursor(&ws.id, &input.session_id);
+
+    // First Stop hook for this session — trigger a background checkpoint for prior sessions.
+    if cursor.byte_offset == 0 && cursor.last_uuid.is_none() {
+        let ws_clone = ws.clone();
+        tokio::spawn(async move {
+            match crate::storage_checkpoint::maybe_create_checkpoint(
+                &ws_clone,
+                None,
+                "new_session_cowork",
+                None,
+            )
+            .await
+            {
+                Err(e) => tracing::debug!("checkpoint generation failed (non-fatal): {e}"),
+                Ok(Err(reason)) => tracing::debug!("checkpoint skipped: {reason:?}"),
+                Ok(Ok(_)) => {}
+            }
+        });
+    }
+
+    let (turns, new_cursor) = parse_transcript(&transcript_path, &cursor, cwd_path)?;
+
+    tracing::info!(
+        turns_count = turns.len(),
+        old_offset = cursor.byte_offset,
+        new_offset = new_cursor.byte_offset,
+        "cowork: parsed transcript"
+    );
+
+    let mut seen = load_turnkeys(&ws.id, &input.session_id);
+    let mut new_keys: Vec<String> = Vec::new();
+    let mut all_touched: Vec<String> = Vec::new();
+    let mut all_assistant_texts: Vec<String> = Vec::new();
+
+    for turn in turns {
+        all_touched.extend(turn.touched_paths.iter().cloned());
+        all_assistant_texts.push(turn.assistant_text.clone());
+
+        if let Some(k) = turn_key(&turn) {
+            if seen.contains(&k) {
+                continue;
+            }
+            seen.insert(k.clone());
+            new_keys.push(k);
+        }
+
+        let source_pointer = build_source_pointer(&transcript_path, &turn);
+        let result = flow
+            .record_turn(RecordTurnEvent {
+                directory: input.cwd.clone(),
+                user_text: turn.user_text,
+                assistant_text: turn.assistant_text,
+                touched_paths: turn.touched_paths,
+                tool_calls: vec![],
+                agent_kind: AgentKind::Cowork,
+                agent_session_id: Some(input.session_id.clone()),
+                usage: turn.usage,
+                grounding_note: None,
+                source_ts_ms: None,
+                source_pointer,
+            })
+            .await;
+        if let Some(error) = result.error {
+            tracing::warn!(error = %error, "cowork: record_turn failed");
+        }
+    }
+
+    append_turnkeys(&ws.id, &input.session_id, &new_keys);
+    save_cursor(&ws.id, &input.session_id, &new_cursor);
+
+    // Stealth PR comment detection
+    {
+        let combined = all_assistant_texts.join("\n");
+        if let Some(pr_url) =
+            crate::companion::shims::opencode_stdio::extract_github_pr_url_pub(&combined)
+        {
+            let session_id = input.session_id.clone();
+            let directory = input.cwd.clone();
+            let em = embed_model.to_string();
+            let ec = embed_cache_dir.map(|s| s.to_string());
+            tokio::spawn(async move {
+                tracing::info!(pr_url, "cowork: detected PR creation — posting unlost comment");
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                if let Err(e) = crate::companion::shims::opencode_stdio::spawn_pr_comment_pub(
+                    &pr_url,
+                    Some(session_id.as_str()),
+                    &directory,
+                    &em,
+                    ec.as_deref(),
+                )
+                .await
+                {
+                    tracing::warn!(error = ?e, pr_url, "cowork: pr-comment spawn failed");
+                }
+            });
+        }
+    }
+
+    // Incremental changelog + git tag ingest
+    if let Some(repo_root) = crate::workspace::git_toplevel(cwd_path) {
+        let changelog_path = repo_root.join("CHANGELOG.md");
+        let changelog_touched = all_touched
+            .iter()
+            .any(|p| p.ends_with("CHANGELOG.md") || p == "CHANGELOG.md");
+        let embedder = crate::embed::load_embedder(
+            embed_model,
+            embed_cache_dir.map(std::path::PathBuf::from),
+            false,
+        )
+        .await;
+        if let Ok(ref embedder) = embedder {
+            let use_color = std::io::IsTerminal::is_terminal(&std::io::stdout())
+                && std::env::var_os("NO_COLOR").is_none();
+            let _ = crate::git::ingest_git_tags(&ws, &repo_root, embedder, use_color).await;
+            if changelog_touched || changelog_path.exists() {
+                let _ =
+                    crate::changelog::ingest_changelog(&ws, &changelog_path, embedder, use_color)
+                        .await;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Entry points
+// ============================================================================
+
+pub async fn run(embed_model: String, embed_cache_dir: Option<String>) -> anyhow::Result<()> {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input)?;
+
+    let hook_input: HookInput = serde_json::from_str(&input)?;
+
+    tracing::info!(
+        hook_event = %hook_input.hook_event_name,
+        session_id = %hook_input.session_id,
+        cwd = %hook_input.cwd,
+        "cowork hook invoked"
+    );
+
+    let config = FlowConfig {
+        embed_model: embed_model.clone(),
+        embed_cache_dir: embed_cache_dir.clone(),
+        extraction_mode: crate::types::ExtractionMode::Hybrid,
+    };
+    let mut flow = Flow::new(config);
+
+    let needs_drain = hook_input.hook_event_name == "Stop";
+
+    match hook_input.hook_event_name.as_str() {
+        "UserPromptSubmit" => handle_user_prompt_submit(&mut flow, &hook_input).await?,
+        "Stop" => {
+            handle_stop(
+                &mut flow,
+                &hook_input,
+                &embed_model,
+                embed_cache_dir.as_deref(),
+            )
+            .await?
+        }
+        _ => {
+            tracing::debug!(event = %hook_input.hook_event_name, "cowork: ignoring unhandled hook event");
+        }
+    }
+
+    if needs_drain {
+        flow.drain().await;
+    }
+
+    Ok(())
+}
+
+pub async fn replay(
+    path: String,
+    transcript_path: String,
+    session_id: Option<String>,
+    from_start: bool,
+    dedupe: bool,
+    clear: bool,
+    extraction_mode: crate::types::ExtractionMode,
+    embed_model: String,
+    embed_cache_dir: Option<String>,
+) -> anyhow::Result<()> {
+    let dir_path = Path::new(&path);
+    let transcript_path_buf = PathBuf::from(&transcript_path);
+
+    let ws = get_or_create_workspace_paths(dir_path)?;
+
+    if clear {
+        clear_replay_data(&ws, session_id.as_deref())?;
+    }
+
+    let transcript_files: Vec<PathBuf> = if transcript_path_buf.is_file() {
+        vec![transcript_path_buf.clone()]
+    } else {
+        let mut files: Vec<PathBuf> = std::fs::read_dir(&transcript_path_buf)?
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .map(|ext| ext == "jsonl")
+                    .unwrap_or(false)
+            })
+            .map(|e| e.path())
+            .collect();
+        files.sort();
+        if files.is_empty() {
+            anyhow::bail!(
+                "No .jsonl files found in directory {}",
+                transcript_path_buf.display()
+            );
+        }
+        files
+    };
+
+    let multiple_sessions = transcript_path_buf.is_dir() && session_id.is_none();
+    let use_color =
+        std::io::IsTerminal::is_terminal(&std::io::stdout()) && std::env::var_os("NO_COLOR").is_none();
+
+    use futures_util::future::join_all;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+
+    let max_concurrency = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .min(8);
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(max_concurrency));
+    let files_done = Arc::new(AtomicU64::new(0));
+
+    let mut handles = Vec::new();
+
+    for file_path in transcript_files {
+        let ws_id = ws.id.clone();
+        let dir_path = dir_path.to_path_buf();
+        let path = path.clone();
+        let session_id = session_id.clone();
+        let transcript_path_buf = transcript_path_buf.clone();
+        let embed_model = embed_model.clone();
+        let embed_cache_dir = embed_cache_dir.clone();
+        let files_done = files_done.clone();
+        let semaphore = semaphore.clone();
+
+        let handle = tokio::spawn(async move {
+            let _permit = semaphore
+                .acquire_owned()
+                .await
+                .map_err(|_| anyhow::anyhow!("semaphore closed"))?;
+
+            let config = FlowConfig {
+                embed_model,
+                embed_cache_dir,
+                extraction_mode,
+            };
+            let mut flow = Flow::new(config);
+
+            let sid = if multiple_sessions {
+                file_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| anyhow::anyhow!("could not infer session_id from filename"))?
+            } else if let Some(ref s) = session_id {
+                s.clone()
+            } else {
+                transcript_path_buf
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| anyhow::anyhow!("missing --session-id"))?
+            };
+
+            let cursor = if from_start {
+                CursorState::default()
+            } else {
+                load_cursor(&ws_id, &sid)
+            };
+
+            let (turns, new_cursor) = parse_transcript(&file_path, &cursor, &dir_path)?;
+
+            let mut seen = if dedupe {
+                load_turnkeys(&ws_id, &sid)
+            } else {
+                HashSet::new()
+            };
+            let mut new_keys: Vec<String> = Vec::new();
+            let mut recorded = 0usize;
+
+            for turn in turns {
+                if dedupe {
+                    if let Some(k) = turn_key(&turn) {
+                        if seen.contains(&k) {
+                            continue;
+                        }
+                        seen.insert(k.clone());
+                        new_keys.push(k);
+                    }
+                }
+
+                let source_pointer = build_source_pointer(&file_path, &turn);
+                let event = RecordTurnEvent {
+                    directory: path.clone(),
+                    user_text: turn.user_text,
+                    assistant_text: turn.assistant_text,
+                    touched_paths: turn.touched_paths,
+                    tool_calls: vec![],
+                    agent_kind: AgentKind::Cowork,
+                    agent_session_id: Some(sid.clone()),
+                    usage: turn.usage,
+                    grounding_note: None,
+                    source_ts_ms: if turn.timestamp_ms > 0 {
+                        Some(turn.timestamp_ms)
+                    } else {
+                        None
+                    },
+                    source_pointer,
+                };
+                let result = flow.record_turn(event).await;
+                if result.error.is_none() {
+                    recorded += 1;
+                }
+            }
+
+            flow.drain().await;
+
+            if dedupe {
+                append_turnkeys(&ws_id, &sid, &new_keys);
+            }
+            save_cursor(&ws_id, &sid, &new_cursor);
+            files_done.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+            Ok::<_, anyhow::Error>((file_path, recorded, flow.llm_calls().await))
+        });
+
+        handles.push(handle);
+    }
+
+    let results = join_all(handles).await;
+
+    let mut grand_recorded = 0usize;
+    for result in results {
+        match result {
+            Ok(Ok((_file, recorded, _llm))) => grand_recorded += recorded,
+            Ok(Err(e)) => eprintln!("Error: {}", e),
+            Err(e) => eprintln!("Task panicked: {}", e),
+        }
+    }
+
+    if use_color {
+        println!(
+            "\x1b[1;32m✓\x1b[0m Replay complete: \x1b[1;36m{}\x1b[0m turns indexed",
+            grand_recorded
+        );
+    } else {
+        println!("Replay complete: {} turns indexed", grand_recorded);
+    }
+
+    Ok(())
+}
+
+fn clear_replay_data(ws: &crate::workspace::WorkspacePaths, session_id: Option<&str>) -> anyhow::Result<()> {
+    let base = crate::workspace::unlost_workspace_dir(&ws.id).join("cowork");
+    if !base.exists() {
+        return Ok(());
+    }
+    if let Some(sid) = session_id {
+        let _ = std::fs::remove_file(base.join(format!("{}.cursor", sid)));
+        let _ = std::fs::remove_file(base.join(format!("{}.turnkeys", sid)));
+    } else {
+        let _ = std::fs::remove_dir_all(&base);
+    }
+    Ok(())
+}

--- a/src/companion/shims/mod.rs
+++ b/src/companion/shims/mod.rs
@@ -4,5 +4,6 @@
 
 pub mod claude;
 pub mod copilot;
+pub mod cowork;
 pub mod opencode;
 pub mod opencode_stdio;

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,6 +381,12 @@ async fn main() -> anyhow::Result<()> {
             } => {
                 unlost::companion::shims::copilot::run(embed_model, embed_cache_dir).await?;
             }
+            ShimCommand::Cowork {
+                embed_model,
+                embed_cache_dir,
+            } => {
+                unlost::companion::shims::cowork::run(embed_model, embed_cache_dir).await?;
+            }
             ShimCommand::Replay { command } => {
                 handle_replay(command).await?;
             }
@@ -491,6 +497,39 @@ async fn handle_replay(command: ReplayCommand) -> anyhow::Result<()> {
                 embed_model,
                 embed_cache_dir,
                 git_grounding,
+            )
+            .await?;
+        }
+        ReplayCommand::Cowork {
+            path,
+            transcript_path,
+            session_id,
+            from_start,
+            dedupe,
+            no_extraction,
+            full_extraction,
+            clear,
+            embed_model,
+            embed_cache_dir,
+        } => {
+            let mode = if no_extraction {
+                unlost::types::ExtractionMode::None
+            } else if full_extraction {
+                unlost::types::ExtractionMode::Full
+            } else {
+                unlost::types::ExtractionMode::Hybrid
+            };
+
+            unlost::companion::shims::cowork::replay(
+                path,
+                transcript_path,
+                session_id,
+                from_start,
+                dedupe,
+                clear,
+                mode,
+                embed_model,
+                embed_cache_dir,
             )
             .await?;
         }


### PR DESCRIPTION
## Summary
- Adds \`unlost shim cowork\` hook shim (UserPromptSubmit friction + Stop recording)
- Adds \`unlost config agent cowork\` to write the plugin package for the Cowork UI
- Adds \`unlost shim replay cowork\` for transcript backfill
- Adds \`agents/cowork/\` plugin package (plugin.json + hooks/hooks.json + .mcp.json)
- Cowork uses the same JSONL transcript format as Claude Code, so the implementation reuses the existing parsing pipeline from \`claude.rs\` — only cursor paths and source pointer scheme differ

## Changelog
- **Claude Cowork integration**: New \`unlost shim cowork\` hook shim, \`unlost shim replay cowork\` backfill command, \`unlost config agent cowork\` installer, and \`agents/cowork/\` plugin package. Cowork shares Claude Code's hook wire format and JSONL transcript schema, so the implementation reuses the same parsing pipeline. Installing the plugin gives Cowork friction detection (\`UserPromptSubmit\`) and automatic session recording (\`Stop\`), plus the unlost MCP connector for in-session memory queries.