### PR TITLE
fix: sync index.html and public/ to gh-pages alongside install.sh

### DIFF
--- a/.github/workflows/sync-gh-pages.yml
+++ b/.github/workflows/sync-gh-pages.yml
@@ -27,14 +27,16 @@ jobs:
           git worktree add gh-pages-wt gh-pages
 
           install -m 0755 docs/install.sh gh-pages-wt/install.sh
+          install -m 0644 docs/index.html gh-pages-wt/index.html
+          cp -r docs/public/. gh-pages-wt/public/
 
           if [ -z "$(git -C gh-pages-wt status --porcelain)" ]; then
             echo "No changes to commit."
             exit 0
           fi
 
-          git -C gh-pages-wt add install.sh
-          git -C gh-pages-wt -c user.name='github-actions[bot]' -c user.email='github-actions[bot]@users.noreply.github.com' commit -m 'docs: sync install.sh'
+          git -C gh-pages-wt add install.sh index.html public/
+          git -C gh-pages-wt -c user.name='github-actions[bot]' -c user.email='github-actions[bot]@users.noreply.github.com' commit -m 'docs: sync install.sh and index.html'
           git -C gh-pages-wt push origin gh-pages
 
       - name: Cleanup worktree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Changed
 
 - **`docs/index.html`**: Updated landing page to cover 0.15.0 and 0.16.0 changes: added `note+local://` to the Source Pointer Registry; enriched `unlost thread` command entry with LLM synthesis, timeline rendering details, and flag examples; enriched `unlost note` entry with `--global` flag and source pointer footer behaviour; added Claude Cowork to the "Any agent. One shared memory." hero row and the Agent Integration install block.
-
 ## [0.16.0] - 2026-05-20
 
 ### Added


### PR DESCRIPTION
## Summary
- The `sync-gh-pages` workflow only copied `install.sh` to the `gh-pages` branch, leaving `index.html` and `public/` assets stale after every docs change
- Add `install -m 0644 docs/index.html gh-pages-wt/index.html` and `cp -r docs/public/. gh-pages-wt/public/` to the sync step
- Update the `git add` and commit message to include the new files

## Changelog
- **`sync-gh-pages` workflow**: Also syncs `docs/index.html` and `docs/public/` to the `gh-pages` branch so the landing page is updated on every push to `main`.