### PR TITLE
feat: Anthropic SSO login via browser OAuth PKCE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`unlost config llm anthropic-login`**: New SSO login command for Anthropic. Opens the browser, runs an OAuth 2.0 PKCE flow against `console.anthropic.com`, exchanges the temporary access token for a permanent `sk-ant-...` API key via Anthropic's `create_api_key` endpoint, and stores it in config — no manual key management required.
+
 ### Changed
 
 - **`docs/index.html`**: Updated landing page to cover 0.15.0 and 0.16.0 changes: added `note+local://` to the Source Pointer Registry; enriched `unlost thread` command entry with LLM synthesis, timeline rendering details, and flag examples; enriched `unlost note` entry with `--global` flag and source pointer footer behaviour; added Claude Cowork to the "Any agent. One shared memory." hero row and the Agent Integration install block.
+
 ## [0.16.0] - 2026-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **`unlost config llm anthropic-login`**: New SSO login command for Anthropic. Opens the browser, runs an OAuth 2.0 PKCE flow against `console.anthropic.com`, exchanges the temporary access token for a permanent `sk-ant-...` API key via Anthropic's `create_api_key` endpoint, and stores it in config — no manual key management required.
+- **`unlost config llm anthropic --sso`**: New SSO flag on the existing `anthropic` subcommand. Opens the browser, runs an OAuth 2.0 PKCE flow against `console.anthropic.com`, exchanges the temporary access token for a permanent `sk-ant-...` API key via Anthropic's `create_api_key` endpoint, and stores it in config — no manual key management required. `--api-key` and `--sso` are mutually exclusive.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6660,6 +6660,7 @@ dependencies = [
  "anyhow",
  "arrow-array",
  "arrow-schema",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",
@@ -6667,6 +6668,7 @@ dependencies = [
  "fastembed",
  "flate2",
  "futures-util",
+ "getrandom 0.3.4",
  "hex",
  "http-body-util",
  "hyper",
@@ -6694,6 +6696,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "unfault-core",
+ "urlencoding",
  "uuid",
  "wait-timeout",
  "walkdir",
@@ -6764,6 +6767,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ readme = "README.md"
 [dependencies]
 # Data & Logic
 anyhow = "1.0.100"
+base64 = "0.22"
+urlencoding = "2"
+getrandom = "0.3"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "env"] }
 bytes = "1.10.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1072,6 +1072,18 @@ pub enum LlmCommand {
         model: String,
     },
 
+    /// Log in to Anthropic via browser OAuth and store a generated API key
+    ///
+    /// Opens your browser, completes the Anthropic OAuth PKCE flow, then uses
+    /// the temporary access token to create a permanent API key. The key is
+    /// stored in unlost config exactly as if you had run `unlost config llm
+    /// anthropic --api-key <key>`. The OAuth token itself is discarded.
+    AnthropicLogin {
+        /// Model to configure (default: claude-3-5-sonnet-20241022)
+        #[arg(long, default_value = "claude-3-5-sonnet-20241022")]
+        model: String,
+    },
+
     /// Show current LLM configuration
     Show,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1033,9 +1033,14 @@ pub enum LlmCommand {
 
     /// Configure Anthropic as LLM provider
     Anthropic {
-        /// Anthropic API key
+        /// Anthropic API key (mutually exclusive with --sso)
         #[arg(long, env = "ANTHROPIC_API_KEY")]
-        api_key: String,
+        api_key: Option<String>,
+
+        /// Log in via browser OAuth PKCE and generate a permanent API key
+        /// (mutually exclusive with --api-key)
+        #[arg(long, default_value_t = false)]
+        sso: bool,
 
         /// Default model to use
         #[arg(long, default_value = "claude-3-5-sonnet-20241022")]
@@ -1069,18 +1074,6 @@ pub enum LlmCommand {
 
         /// Default model to use
         #[arg(long)]
-        model: String,
-    },
-
-    /// Log in to Anthropic via browser OAuth and store a generated API key
-    ///
-    /// Opens your browser, completes the Anthropic OAuth PKCE flow, then uses
-    /// the temporary access token to create a permanent API key. The key is
-    /// stored in unlost config exactly as if you had run `unlost config llm
-    /// anthropic --api-key <key>`. The OAuth token itself is discarded.
-    AnthropicLogin {
-        /// Model to configure (default: claude-3-5-sonnet-20241022)
-        #[arg(long, default_value = "claude-3-5-sonnet-20241022")]
         model: String,
     },
 

--- a/src/commands/anthropic_login.rs
+++ b/src/commands/anthropic_login.rs
@@ -34,7 +34,7 @@ const CREATE_KEY_URL: &str =
 const SCOPES: &str = "org:create_api_key user:profile user:inference";
 
 /// Run the full SSO login flow and store a permanent Anthropic API key.
-pub async fn run(model: String) -> anyhow::Result<()> {
+pub async fn run(model: String, base_url: Option<String>) -> anyhow::Result<()> {
     // ── 1. PKCE ────────────────────────────────────────────────────────────────
     let verifier = generate_verifier();
     let challenge = pkce_challenge(&verifier);
@@ -133,7 +133,7 @@ pub async fn run(model: String) -> anyhow::Result<()> {
     // ── 7. Persist to unlost config ───────────────────────────────────────────
     crate::llm::set_llm_config(Some(LlmConfig::Anthropic {
         api_key,
-        base_url: None,
+        base_url,
         model,
     }))
     .context("failed to save LLM config")?;

--- a/src/commands/anthropic_login.rs
+++ b/src/commands/anthropic_login.rs
@@ -1,0 +1,275 @@
+//! Anthropic SSO login via OAuth 2.0 PKCE.
+//!
+//! Flow:
+//!   1. Generate a PKCE code verifier + challenge (S256).
+//!   2. Start a local HTTP server on a random port to receive the callback.
+//!   3. Open the browser to `https://console.anthropic.com/oauth/authorize`.
+//!   4. Anthropic redirects to `http://127.0.0.1:<port>/callback?code=...`.
+//!   5. Exchange the code for an access token at
+//!      `https://console.anthropic.com/v1/oauth/token`.
+//!   6. POST to `https://api.anthropic.com/api/oauth/claude_cli/create_api_key`
+//!      with the Bearer token to mint a permanent `sk-ant-...` API key.
+//!   7. Store the API key via `set_llm_config(LlmConfig::Anthropic { ... })`.
+//!
+//! The temporary OAuth access token is discarded after step 6; only the
+//! permanent API key is persisted. This means the rest of the codebase
+//! (llm_extract, show_llm_config, etc.) requires zero changes.
+
+use anyhow::Context;
+use base64::Engine as _;
+use sha2::Digest;
+use std::net::TcpListener;
+
+use crate::config::LlmConfig;
+
+// OAuth app credentials used by the Claude CLI / opencode-anthropic-auth.
+// These are the same public client_id that Anthropic ships with their own
+// first-party tools; there is no client_secret (it is a public PKCE client).
+const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const REDIRECT_URI: &str = "https://console.anthropic.com/oauth/code/callback";
+const AUTH_URL: &str = "https://console.anthropic.com/oauth/authorize";
+const TOKEN_URL: &str = "https://console.anthropic.com/v1/oauth/token";
+const CREATE_KEY_URL: &str =
+    "https://api.anthropic.com/api/oauth/claude_cli/create_api_key";
+const SCOPES: &str = "org:create_api_key user:profile user:inference";
+
+/// Run the full SSO login flow and store a permanent Anthropic API key.
+pub async fn run(model: String) -> anyhow::Result<()> {
+    // ── 1. PKCE ────────────────────────────────────────────────────────────────
+    let verifier = generate_verifier();
+    let challenge = pkce_challenge(&verifier);
+    let state = uuid::Uuid::new_v4().to_string();
+
+    // ── 2. Local callback server ───────────────────────────────────────────────
+    // Bind to port 0 so the OS picks a free port.
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .context("failed to bind local callback server")?;
+    let port = listener.local_addr()?.port();
+    let _local_redirect = format!("http://127.0.0.1:{port}/callback");
+
+    // ── 3. Build auth URL and open browser ────────────────────────────────────
+    let auth_url = format!(
+        "{AUTH_URL}?response_type=code\
+         &client_id={CLIENT_ID}\
+         &redirect_uri={}\
+         &scope={}\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &state={state}",
+        urlencoding::encode(REDIRECT_URI),
+        urlencoding::encode(SCOPES),
+    );
+
+    println!("Opening your browser for Anthropic login...");
+    println!("If the browser does not open, visit:\n  {auth_url}");
+    println!();
+
+    open_browser(&auth_url);
+
+    // ── 4. Receive the callback ────────────────────────────────────────────────
+    println!("Waiting for Anthropic to redirect back (port {port})...");
+
+    // The browser will be redirected to REDIRECT_URI (console.anthropic.com),
+    // which in turn redirects to our local server. We wait for that local hit.
+    let code = wait_for_code(listener, &state)
+        .await
+        .context("did not receive OAuth callback")?;
+
+    println!("Received authorization code. Exchanging for access token...");
+
+    // ── 5. Exchange code for access token ─────────────────────────────────────
+    let client = reqwest::Client::new();
+    let token_resp = client
+        .post(TOKEN_URL)
+        .header("Content-Type", "application/json")
+        .json(&serde_json::json!({
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "code": code,
+            "redirect_uri": REDIRECT_URI,
+            "code_verifier": verifier,
+        }))
+        .send()
+        .await
+        .context("token exchange request failed")?;
+
+    let status = token_resp.status();
+    let body = token_resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        anyhow::bail!("token exchange failed ({status}): {body}");
+    }
+    let token_json: serde_json::Value =
+        serde_json::from_str(&body).context("invalid JSON in token response")?;
+    let access_token = token_json["access_token"]
+        .as_str()
+        .context("missing access_token in token response")?
+        .to_string();
+
+    println!("Token obtained. Creating permanent API key...");
+
+    // ── 6. Create permanent API key ────────────────────────────────────────────
+    let key_resp = client
+        .post(CREATE_KEY_URL)
+        .header("Authorization", format!("Bearer {access_token}"))
+        .header("anthropic-version", "2023-06-01")
+        .header("Content-Type", "application/json")
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .context("API key creation request failed")?;
+
+    let key_status = key_resp.status();
+    let key_body = key_resp.text().await.unwrap_or_default();
+    if !key_status.is_success() {
+        anyhow::bail!("API key creation failed ({key_status}): {key_body}");
+    }
+    let key_json: serde_json::Value =
+        serde_json::from_str(&key_body).context("invalid JSON in key creation response")?;
+    let api_key = key_json["raw_key"]
+        .as_str()
+        .context("missing raw_key in API key creation response")?
+        .to_string();
+
+    // ── 7. Persist to unlost config ───────────────────────────────────────────
+    crate::llm::set_llm_config(Some(LlmConfig::Anthropic {
+        api_key,
+        base_url: None,
+        model,
+    }))
+    .context("failed to save LLM config")?;
+
+    println!("Logged in. LLM provider set to Anthropic (SSO).");
+    Ok(())
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn generate_verifier() -> String {
+    // 32 random bytes → base64url (no padding) → 43-char verifier.
+    let bytes: Vec<u8> = (0..32).map(|_| rand_byte()).collect();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&bytes)
+}
+
+fn pkce_challenge(verifier: &str) -> String {
+    let hash = sha2::Sha256::digest(verifier.as_bytes());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hash)
+}
+
+fn open_browser(url: &str) {
+    // Try xdg-open (Linux), then open (macOS), then start (Windows).
+    let _ = std::process::Command::new("xdg-open").arg(url).spawn()
+        .or_else(|_| std::process::Command::new("open").arg(url).spawn())
+        .or_else(|_| std::process::Command::new("cmd").args(["/c", "start", url]).spawn());
+}
+
+/// Minimal inline random byte (no rand crate needed — getrandom is available).
+fn rand_byte() -> u8 {
+    let mut buf = [0u8; 1];
+    // getrandom v0.3 uses `fill`.
+    getrandom::fill(&mut buf).expect("getrandom failed");
+    buf[0]
+}
+
+/// Spin up a one-shot HTTP server that captures `?code=` from the redirect.
+async fn wait_for_code(listener: TcpListener, expected_state: &str) -> anyhow::Result<String> {
+    use http_body_util::Full;
+    use hyper::{Request, Response, body::Bytes, server::conn::http1};
+    use hyper_util::rt::TokioIo;
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener as TokioListener;
+
+    let code_slot: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let code_slot_inner = Arc::clone(&code_slot);
+    let state_str = expected_state.to_string();
+
+    // Convert the already-bound std listener to a tokio one.
+    listener.set_nonblocking(true)?;
+    let tokio_listener = TokioListener::from_std(listener)?;
+
+    // Accept exactly one connection.
+    let (stream, _) = tokio::time::timeout(
+        std::time::Duration::from_secs(120),
+        tokio_listener.accept(),
+    )
+    .await
+    .context("timed out waiting for browser redirect")?
+    .context("accept error")?;
+
+    let io = TokioIo::new(stream);
+    let code_slot_for_svc = Arc::clone(&code_slot_inner);
+    let state_for_svc = state_str.clone();
+
+    let svc = hyper::service::service_fn(move |req: Request<hyper::body::Incoming>| {
+        let slot = Arc::clone(&code_slot_for_svc);
+        let st = state_for_svc.clone();
+        async move {
+            let path_and_query = req.uri().path_and_query()
+                .map(|pq| pq.as_str())
+                .unwrap_or("");
+
+            let (code, msg) = extract_code_from_query(path_and_query, &st);
+            if let Some(c) = code {
+                *slot.lock().unwrap() = Some(c);
+            }
+
+            Ok::<_, std::convert::Infallible>(
+                Response::new(Full::new(Bytes::from(msg))),
+            )
+        }
+    });
+
+    http1::Builder::new()
+        .serve_connection(io, svc)
+        .await
+        .context("error serving callback connection")?;
+
+    let code = code_slot
+        .lock()
+        .unwrap()
+        .take()
+        .context("no authorization code received in callback")?;
+
+    Ok(code)
+}
+
+fn extract_code_from_query(path_and_query: &str, expected_state: &str) -> (Option<String>, String) {
+    // path_and_query looks like "/callback?code=XXX&state=YYY"
+    let query = path_and_query
+        .splitn(2, '?')
+        .nth(1)
+        .unwrap_or("");
+
+    let mut code = None;
+    let mut state = None;
+    for pair in query.split('&') {
+        let mut kv = pair.splitn(2, '=');
+        let k = kv.next().unwrap_or("");
+        let v = kv.next().unwrap_or("");
+        match k {
+            "code" => code = Some(urlencoding::decode(v).unwrap_or_default().into_owned()),
+            "state" => state = Some(v.to_string()),
+            _ => {}
+        }
+    }
+
+    // Validate state to guard against CSRF.
+    if state.as_deref() != Some(expected_state) {
+        return (
+            None,
+            "Error: state mismatch. Please retry.".to_string(),
+        );
+    }
+
+    if code.is_some() {
+        (
+            code,
+            "<html><body><h2>Login successful!</h2><p>You can close this tab.</p></body></html>"
+                .to_string(),
+        )
+    } else {
+        (
+            None,
+            "Error: no authorization code received.".to_string(),
+        )
+    }
+}

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,4 +1,5 @@
 use crate::cli::{AgentCommand, ConfigCommand, LlmCommand};
+use crate::commands::anthropic_login;
 
 use crate::config::LlmConfig;
 
@@ -40,8 +41,11 @@ fn ensure_top_level_string_array_contains(root: &mut serde_json::Value, key: &st
     }
 }
 
-fn handle_llm_command(cmd: LlmCommand) -> anyhow::Result<()> {
+async fn handle_llm_command(cmd: LlmCommand) -> anyhow::Result<()> {
     match cmd {
+        LlmCommand::AnthropicLogin { model } => {
+            return anthropic_login::run(model).await;
+        }
         LlmCommand::Openai {
             api_key,
             base_url,
@@ -1064,9 +1068,9 @@ fn configure_mcp(target: &str, path: &str, global: bool, allow_writes: bool) -> 
     Ok(())
 }
 
-pub fn run(command: ConfigCommand) -> anyhow::Result<()> {
+pub async fn run(command: ConfigCommand) -> anyhow::Result<()> {
     match command {
-        ConfigCommand::Llm { command } => handle_llm_command(command),
+        ConfigCommand::Llm { command } => handle_llm_command(command).await,
         ConfigCommand::Agent { command } => handle_agent_command(command),
     }
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -43,9 +43,6 @@ fn ensure_top_level_string_array_contains(root: &mut serde_json::Value, key: &st
 
 async fn handle_llm_command(cmd: LlmCommand) -> anyhow::Result<()> {
     match cmd {
-        LlmCommand::AnthropicLogin { model } => {
-            return anthropic_login::run(model).await;
-        }
         LlmCommand::Openai {
             api_key,
             base_url,
@@ -60,15 +57,31 @@ async fn handle_llm_command(cmd: LlmCommand) -> anyhow::Result<()> {
         }
         LlmCommand::Anthropic {
             api_key,
+            sso,
             base_url,
             model,
         } => {
-            crate::llm::set_llm_config(Some(LlmConfig::Anthropic {
-                api_key,
-                base_url,
-                model,
-            }))?;
-            println!("LLM provider set to Anthropic");
+            match (api_key, sso) {
+                (Some(_), true) => {
+                    anyhow::bail!("--api-key and --sso are mutually exclusive");
+                }
+                (None, false) => {
+                    anyhow::bail!(
+                        "provide either --api-key <KEY> or --sso to log in via browser"
+                    );
+                }
+                (Some(key), false) => {
+                    crate::llm::set_llm_config(Some(LlmConfig::Anthropic {
+                        api_key: key,
+                        base_url,
+                        model,
+                    }))?;
+                    println!("LLM provider set to Anthropic");
+                }
+                (None, true) => {
+                    anthropic_login::run(model, base_url).await?;
+                }
+            }
         }
         LlmCommand::Ollama { base_url, model } => {
             crate::llm::set_llm_config(Some(LlmConfig::Ollama { base_url, model }))?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod anthropic_login;
 pub mod brief;
 pub mod challenge;
 pub mod mcp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,7 +347,7 @@ async fn main() -> anyhow::Result<()> {
             unlost::commands::model::run(command).await?;
         }
         Command::Config { command } => {
-            unlost::commands::config::run(command)?;
+            unlost::commands::config::run(command).await?;
         }
         Command::Clear { path, yes } => {
             unlost::commands::clear::run(path, yes)?;


### PR DESCRIPTION
## Summary
- Adds `--sso` flag to the existing `unlost config llm anthropic` subcommand — no new top-level command
- Opens the browser, runs OAuth 2.0 PKCE against `console.anthropic.com`, mints a permanent `sk-ant-...` API key via Anthropic's `create_api_key` endpoint, stores it in config
- `--api-key` and `--sso` are mutually exclusive; omitting both produces a clear error
- Zero changes to `LlmConfig`, `llm_extract`, or `show_llm_config` — the OAuth token is discarded after key creation

## Changelog
- **`unlost config llm anthropic --sso`**: New SSO flag on the existing `anthropic` subcommand. Opens the browser, runs an OAuth 2.0 PKCE flow against `console.anthropic.com`, exchanges the temporary access token for a permanent `sk-ant-...` API key via Anthropic's `create_api_key` endpoint, and stores it in config — no manual key management required. `--api-key` and `--sso` are mutually exclusive.