### PR TITLE
fix: tolerate null string fields in reindex capsule deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`unlost reindex`**: Tolerate capsules with `null` string fields (`category`, `intent`, `decision`, `rationale`, `request_path`, `source`) instead of crashing with `invalid type: null, expected a string`. Adds `#[serde(default)]` to those fields so older or partially-written records are skipped gracefully rather than aborting a full reindex mid-run.
+
 ## [0.17.0] - 2026-06-15
 
 ### Added

--- a/src/commands/reindex.rs
+++ b/src/commands/reindex.rs
@@ -14,7 +14,9 @@ struct JsonCapsule {
     ts_ms: i64,
     conn_id: u64,
     exchange_seq: u64,
+    #[serde(default)]
     request_path: String,
+    #[serde(default)]
     source: String,
     #[serde(default)]
     usage: Option<Usage>,
@@ -51,9 +53,13 @@ struct Cache {
 
 #[derive(Deserialize)]
 struct Caps {
+    #[serde(default)]
     category: String,
+    #[serde(default)]
     intent: String,
+    #[serde(default)]
     decision: String,
+    #[serde(default)]
     rationale: String,
     next_steps: Vec<String>,
     symbols: Vec<String>,


### PR DESCRIPTION
## Summary
- Adds `#[serde(default)]` to required `String` fields in `JsonCapsule` (`request_path`, `source`) and `Caps` (`category`, `intent`, `decision`, `rationale`) in `reindex.rs`
- Prevents `unlost reindex` from crashing mid-run with `invalid type: null, expected a string` when a capsule in the JSONL has a null value for any of those fields
- Null fields are substituted with empty strings, allowing the reindex to complete

## Changelog
- **`unlost reindex`**: Tolerate capsules with `null` string fields (`category`, `intent`, `decision`, `rationale`, `request_path`, `source`) instead of crashing with `invalid type: null, expected a string`. Adds `#[serde(default)]` to those fields so older or partially-written records are skipped gracefully rather than aborting a full reindex mid-run.