### PR TITLE
feat: add --no-llm flag to all LLM-using commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`--no-llm` flag on all LLM-using commands**: `recall`, `brief`, `reflect`, `explore`, `challenge`, and `pr-comment` now all accept `--no-llm` to skip the LLM narrative and print raw capsule data instead. Allows full use of unlost memory commands on machines without an LLM configured. `query`, `trace`, `thread`, and `init` already had this flag; this change brings the remaining commands in line.
+
 ## [0.18.3] - 2026-06-22
 
 ### Fixed

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -295,6 +295,10 @@ pub enum Command {
         #[arg(long)]
         from_commit: Option<String>,
 
+        /// Disable LLM narrative (posts a minimal comment with raw capsule list only)
+        #[arg(long, default_value_t = false)]
+        no_llm: bool,
+
         /// LLM model to use for the PR comment narrative
         #[arg(long)]
         llm_model: Option<String>,
@@ -312,6 +316,10 @@ pub enum Command {
     Brief {
         /// Optional scope: file path, symbol, or concept to focus the brief on
         target: Vec<String>,
+
+        /// Disable LLM narrative (prints raw scored capsules)
+        #[arg(long, default_value_t = false)]
+        no_llm: bool,
 
         /// LLM model to use for the brief
         #[arg(long)]
@@ -359,6 +367,10 @@ pub enum Command {
         #[arg(long)]
         until: Option<String>,
 
+        /// Disable LLM narrative (prints raw capsules)
+        #[arg(long, default_value_t = false)]
+        no_llm: bool,
+
         /// LLM model to use for recall narrative
         #[arg(long)]
         llm_model: Option<String>,
@@ -394,6 +406,10 @@ pub enum Command {
         #[arg(long)]
         since: Option<String>,
 
+        /// Disable LLM narrative (prints raw turn evaluation data)
+        #[arg(long, default_value_t = false)]
+        no_llm: bool,
+
         /// LLM model to use for the reflection narrative
         #[arg(long)]
         llm_model: Option<String>,
@@ -415,6 +431,10 @@ pub enum Command {
     Explore {
         /// Scenario or goal to explore (e.g. "should we keep lancedb or move to sqlite+fts?")
         query: Vec<String>,
+
+        /// Disable LLM narrative (prints raw scored capsules)
+        #[arg(long, default_value_t = false)]
+        no_llm: bool,
 
         /// LLM model to use for the exploration narrative
         #[arg(long)]
@@ -445,6 +465,10 @@ pub enum Command {
         /// Show full analysis: adds UNKNOWNS and PROBES sections (default: concise)
         #[arg(long, default_value_t = false)]
         deep: bool,
+
+        /// Disable LLM narrative (prints raw scored capsules)
+        #[arg(long, default_value_t = false)]
+        no_llm: bool,
 
         /// LLM model to use for the challenge narrative
         #[arg(long)]

--- a/src/commands/brief.rs
+++ b/src/commands/brief.rs
@@ -207,6 +207,7 @@ fn checkpoint_as_capsule_hit(
 
 pub async fn run(
     target: Vec<String>,
+    no_llm: bool,
     llm_model: Option<String>,
     output: OutputFormat,
     embed_model: String,
@@ -263,7 +264,7 @@ pub async fn run(
     // ── Checkpoint fast path (unscoped only) ─────────────────────────────────
     // When not scoped, try to synthesize from stored checkpoint narratives.
     // This is significantly cheaper than processing 200 raw capsules.
-    if scope_opt.is_none() {
+    if !no_llm && scope_opt.is_none() {
         if let Some(result) = try_checkpoint_brief(&ws, &workspace_root, llm_model.as_deref(), output).await {
             if let Some(pb) = spinner.as_ref() {
                 pb.finish_and_clear();
@@ -314,6 +315,34 @@ pub async fn run(
             println!("No capsules found yet for this workspace.");
             println!("Run `unlost recall` after a few coding sessions to build up memory.");
         }
+        return Ok(());
+    }
+
+    if no_llm {
+        if let Some(pb) = spinner.as_ref() {
+            pb.finish_and_clear();
+        }
+        // Print raw capsules without LLM narrative
+        for hit in &hits {
+            let cap = &hit.capsule;
+            println!("---");
+            println!("category:  {}", cap.category);
+            if !cap.intent.trim().is_empty() {
+                println!("intent:    {}", cap.intent);
+            }
+            if !cap.decision.trim().is_empty() {
+                println!("decision:  {}", cap.decision);
+            }
+            if !cap.rationale.trim().is_empty() {
+                println!("rationale: {}", cap.rationale);
+            }
+            if !cap.next_steps.is_empty() {
+                println!("next:      {:?}", cap.next_steps);
+            }
+            println!("symbols:   {:?}", cap.symbols);
+            println!();
+        }
+        println!();
         return Ok(());
     }
 

--- a/src/commands/challenge.rs
+++ b/src/commands/challenge.rs
@@ -100,6 +100,7 @@ fn select_hits_for_challenge(
 pub async fn run(
     target: Vec<String>,
     deep: bool,
+    no_llm: bool,
     llm_model: Option<String>,
     output: OutputFormat,
     embed_model: String,
@@ -187,6 +188,34 @@ pub async fn run(
         }
         println!("No capsules found yet for this workspace.");
         println!("Run `unlost init` or record a few coding sessions first.");
+        return Ok(());
+    }
+
+    if no_llm {
+        if let Some(pb) = spinner.as_ref() {
+            pb.finish_and_clear();
+        }
+        // Print raw scored capsules without LLM narrative
+        for hit in &hits {
+            let cap = &hit.capsule;
+            println!("---");
+            println!("category:  {}", cap.category);
+            if !cap.intent.trim().is_empty() {
+                println!("intent:    {}", cap.intent);
+            }
+            if !cap.decision.trim().is_empty() {
+                println!("decision:  {}", cap.decision);
+            }
+            if !cap.rationale.trim().is_empty() {
+                println!("rationale: {}", cap.rationale);
+            }
+            if !cap.next_steps.is_empty() {
+                println!("next:      {:?}", cap.next_steps);
+            }
+            println!("symbols:   {:?}", cap.symbols);
+            println!();
+        }
+        println!();
         return Ok(());
     }
 

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -102,6 +102,7 @@ fn select_hits_for_exploration(
 
 pub async fn run(
     query: Vec<String>,
+    no_llm: bool,
     llm_model: Option<String>,
     output: OutputFormat,
     embed_model: String,
@@ -189,6 +190,34 @@ pub async fn run(
         }
         println!("No capsules found yet for this workspace.");
         println!("Run `unlost init` or record a few coding sessions first.");
+        return Ok(());
+    }
+
+    if no_llm {
+        if let Some(pb) = spinner.as_ref() {
+            pb.finish_and_clear();
+        }
+        // Print raw scored capsules without LLM narrative
+        for hit in &hits {
+            let cap = &hit.capsule;
+            println!("---");
+            println!("category:  {}", cap.category);
+            if !cap.intent.trim().is_empty() {
+                println!("intent:    {}", cap.intent);
+            }
+            if !cap.decision.trim().is_empty() {
+                println!("decision:  {}", cap.decision);
+            }
+            if !cap.rationale.trim().is_empty() {
+                println!("rationale: {}", cap.rationale);
+            }
+            if !cap.next_steps.is_empty() {
+                println!("next:      {:?}", cap.next_steps);
+            }
+            println!("symbols:   {:?}", cap.symbols);
+            println!();
+        }
+        println!();
         return Ok(());
     }
 

--- a/src/commands/pr_comment.rs
+++ b/src/commands/pr_comment.rs
@@ -15,6 +15,7 @@ pub async fn run(
     pr: String,
     session_id: Option<String>,
     from_commit: Option<String>,
+    no_llm: bool,
     llm_model: Option<String>,
     embed_model: String,
     embed_cache_dir: Option<String>,
@@ -83,15 +84,19 @@ pub async fn run(
     let worth_noting =
         build_worth_noting_section(&workspace_root, &pr_meta.changed_files);
 
-    // ── 5. Generate the markdown comment body via LLM ─────────────────────────
-    let comment_body = build_pr_comment_markdown(
-        llm_model.as_deref(),
-        &pr_meta,
-        &chain,
-        &worth_noting,
-        &workspace_root.to_string_lossy(),
-    )
-    .await?;
+    // ── 5. Generate the markdown comment body (LLM or raw) ───────────────────
+    let comment_body = if no_llm {
+        build_pr_comment_no_llm(&pr_meta, &chain, &worth_noting)
+    } else {
+        build_pr_comment_markdown(
+            llm_model.as_deref(),
+            &pr_meta,
+            &chain,
+            &worth_noting,
+            &workspace_root.to_string_lossy(),
+        )
+        .await?
+    };
 
     // ── 6. Post via gh pr comment ─────────────────────────────────────────────
     post_pr_comment(&pr_ref, &comment_body)
@@ -391,6 +396,71 @@ fn build_worth_noting_section(
     }
 
     notes.join("\n\n")
+}
+
+// ============================================================================
+// No-LLM fallback: minimal PR comment with raw capsule list
+// ============================================================================
+
+fn build_pr_comment_no_llm(
+    pr_meta: &PrMeta,
+    chain: &[crate::CapsuleHit],
+    worth_noting: &str,
+) -> String {
+    let mut body = String::new();
+
+    let hook = if chain.is_empty() {
+        "> **[unlost](https://unlost.unfault.dev)** found no recorded decisions for this PR.\n\n"
+            .to_string()
+    } else {
+        format!(
+            "> **[unlost](https://unlost.unfault.dev)** found {} recorded decision{} from the coding session.\n\n",
+            chain.len(),
+            if chain.len() == 1 { "" } else { "s" },
+        )
+    };
+    body.push_str(&hook);
+    body.push_str("## unlost context\n\n");
+    body.push_str(&format!(
+        "**PR #{} — {}**  \n",
+        pr_meta.number, pr_meta.title
+    ));
+    body.push_str(&format!(
+        "Changed files ({}): {}\n\n",
+        pr_meta.changed_files.len(),
+        pr_meta.changed_files.iter().take(15).cloned().collect::<Vec<_>>().join(", ")
+    ));
+
+    if !chain.is_empty() {
+        body.push_str("### Recorded decisions\n\n");
+        for (i, hit) in chain.iter().enumerate() {
+            let cap = &hit.capsule;
+            body.push_str(&format!("{}. ", i + 1));
+            if !cap.intent.trim().is_empty() {
+                body.push_str(&format!("**Intent:** {}  \n", cap.intent.replace('\n', " ")));
+            }
+            if !cap.decision.trim().is_empty() {
+                body.push_str(&format!("   **Decision:** {}  \n", cap.decision.replace('\n', " ")));
+            }
+            if !cap.rationale.trim().is_empty() {
+                body.push_str(&format!("   **Rationale:** {}  \n", cap.rationale.replace('\n', " ")));
+            }
+            if !cap.symbols.is_empty() {
+                let syms = cap.symbols.iter().take(6).cloned().collect::<Vec<_>>().join(", ");
+                body.push_str(&format!("   **Symbols:** `{}`  \n", syms));
+            }
+            body.push('\n');
+        }
+    }
+
+    if !worth_noting.is_empty() {
+        body.push_str("### Worth noting\n\n");
+        body.push_str(worth_noting);
+        body.push('\n');
+    }
+
+    body.push_str("\n---\n_[unlost](https://unlost.unfault.dev) -- local-first session memory. (no-llm mode)_\n");
+    body
 }
 
 // ============================================================================

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -291,6 +291,7 @@ pub async fn run(
     provider: Option<crate::cli::ProviderType>,
     since: Option<String>,
     until: Option<String>,
+    no_llm: bool,
     llm_model: Option<String>,
     output: OutputFormat,
     embed_model: String,
@@ -357,7 +358,8 @@ pub async fn run(
     // When there's no scope filter, try to serve from the most recent checkpoint
     // plus a small delta of new capsules since the checkpoint. This avoids an
     // LLM call for every recall invocation.
-    if scope_opt.is_none()
+    if !no_llm
+        && scope_opt.is_none()
         && since_ms.is_none()
         && until_ms.is_none()
         && emotion_label.is_none()
@@ -502,6 +504,34 @@ pub async fn run(
         } else {
             println!("No capsules found yet for this workspace.");
         }
+        return Ok(());
+    }
+
+    if no_llm {
+        if let Some(pb) = spinner.as_ref() {
+            pb.finish_and_clear();
+        }
+        // Print raw capsules without LLM narrative
+        for hit in &hits {
+            let cap = &hit.capsule;
+            println!("---");
+            println!("category:  {}", cap.category);
+            if !cap.intent.trim().is_empty() {
+                println!("intent:    {}", cap.intent);
+            }
+            if !cap.decision.trim().is_empty() {
+                println!("decision:  {}", cap.decision);
+            }
+            if !cap.rationale.trim().is_empty() {
+                println!("rationale: {}", cap.rationale);
+            }
+            if !cap.next_steps.is_empty() {
+                println!("next:      {:?}", cap.next_steps);
+            }
+            println!("symbols:   {:?}", cap.symbols);
+            println!();
+        }
+        println!();
         return Ok(());
     }
 

--- a/src/commands/reflect.rs
+++ b/src/commands/reflect.rs
@@ -152,6 +152,7 @@ pub async fn run(
     mode: crate::cli::ReflectMode,
     session: Option<String>,
     since: Option<String>,
+    no_llm: bool,
     llm_model: Option<String>,
     output: OutputFormat,
     path: String,
@@ -209,6 +210,24 @@ pub async fn run(
             "TurnEval is collected on new sessions going forward. \
              Try again after recording a new session."
         );
+        return Ok(());
+    }
+
+    if no_llm {
+        if let Some(pb) = spinner.as_ref() {
+            pb.finish_and_clear();
+        }
+        // Print raw turn evaluation data without LLM narrative
+        println!("Turn evaluation data ({} turns):", eval_capsules.len());
+        for hit in &eval_capsules {
+            if let Some(ref eval) = hit.turn_eval {
+                println!("---");
+                println!("session:   {:?}", hit.meta.agent_session_id);
+                println!("category:  {}", hit.capsule.category);
+                println!("eval:      {:?}", eval);
+            }
+        }
+        println!();
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,7 @@ async fn main() -> anyhow::Result<()> {
             pr,
             session_id,
             from_commit,
+            no_llm,
             llm_model,
             embed_model,
             embed_cache_dir,
@@ -169,6 +170,7 @@ async fn main() -> anyhow::Result<()> {
                 pr,
                 session_id,
                 from_commit,
+                no_llm,
                 llm_model,
                 embed_model,
                 embed_cache_dir,
@@ -177,6 +179,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Command::Brief {
             target,
+            no_llm,
             llm_model,
             output,
             plain,
@@ -184,24 +187,26 @@ async fn main() -> anyhow::Result<()> {
             embed_cache_dir,
         } => {
             let output = if plain { OutputFormat::Plain } else { output };
-            unlost::commands::brief::run(target, llm_model, output, embed_model, embed_cache_dir)
+            unlost::commands::brief::run(target, no_llm, llm_model, output, embed_model, embed_cache_dir)
                 .await?;
         }
         Command::Reflect {
             mode,
             session,
             since,
+            no_llm,
             llm_model,
             output,
             plain,
             path,
         } => {
             let output = if plain { OutputFormat::Plain } else { output };
-            unlost::commands::reflect::run(mode, session, since, llm_model, output, path)
+            unlost::commands::reflect::run(mode, session, since, no_llm, llm_model, output, path)
                 .await?;
         }
         Command::Explore {
             query,
+            no_llm,
             llm_model,
             output,
             plain,
@@ -209,12 +214,13 @@ async fn main() -> anyhow::Result<()> {
             embed_cache_dir,
         } => {
             let output = if plain { OutputFormat::Plain } else { output };
-            unlost::commands::explore::run(query, llm_model, output, embed_model, embed_cache_dir)
+            unlost::commands::explore::run(query, no_llm, llm_model, output, embed_model, embed_cache_dir)
                 .await?;
         }
         Command::Challenge {
             target,
             deep,
+            no_llm,
             llm_model,
             output,
             plain,
@@ -223,7 +229,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let output = if plain { OutputFormat::Plain } else { output };
             unlost::commands::challenge::run(
-                target, deep, llm_model, output, embed_model, embed_cache_dir,
+                target, deep, no_llm, llm_model, output, embed_model, embed_cache_dir,
             )
             .await?;
         }
@@ -260,6 +266,7 @@ async fn main() -> anyhow::Result<()> {
             provider,
             since,
             until,
+            no_llm,
             llm_model,
             output,
             plain,
@@ -274,6 +281,7 @@ async fn main() -> anyhow::Result<()> {
                 provider,
                 since,
                 until,
+                no_llm,
                 llm_model,
                 output,
                 embed_model,


### PR DESCRIPTION
## Summary
- Added `--no-llm` flag to `recall`, `brief`, `reflect`, `explore`, `challenge`, and `pr-comment` commands
- When set, skips the LLM narrative and prints raw capsule data to stdout instead
- Brings these commands in line with `query`, `trace`, `thread`, and `init` which already had this flag
- Enables full use of unlost memory commands on machines without an LLM configured

## Changelog
- **`--no-llm` flag on all LLM-using commands**: `recall`, `brief`, `reflect`, `explore`, `challenge`, and `pr-comment` now all accept `--no-llm` to skip the LLM narrative and print raw capsule data instead. Allows full use of unlost memory commands on machines without an LLM configured. `query`, `trace`, `thread`, and `init` already had this flag; this change brings the remaining commands in line.

Closes #45