### PR TITLE
feat: --output json on all commands + unlost ingest for markdown docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-06-22
+
+### Added
+
+- **`--output json` / `--json` flag**: All retrieval commands (`query`, `trace`, `recall`, `brief`, `explore`, `challenge`, `reflect`, `thread`) now accept `--output json` (or the `--json` shortcut). Combined with `--no-llm`, this produces a stable JSON array of capsule objects — no LLM required, no text parsing needed. Schema: `id`, `ts_ms`, `time_utc`, `source`, `category`, `intent`, `decision`, `rationale`, `next_steps`, `symbols`, `failure_mode`, `agent_session_id`, `source_pointer`, `distance`.
+- **`unlost ingest <file.md>`**: New command that chunks a markdown document into capsules by `##` / `###` heading. Parses YAML frontmatter (`target`, `target_path`, `symbols`, `related`, `category`), extracts `[[wiki-links]]`, code-fence language tags, and inline backtick identifiers as symbols. Tags capsules `category: cartography` by default (overridable with `--category`). No LLM required — uses only the embedding model. Supports multiple files in one invocation and `--global` for the global workspace.
+
 ## [0.19.0] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6655,7 +6655,7 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unlost"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name = "unlost"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 authors = ["Sylvain Hellegouarch <sylvain@unfault.dev>"]
 description = "Unlost - Local-first code memory for a workspace."

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,7 @@ unlost {version}
 
 Memory:
   note        Capture a manual note (terminal, stdin, any thought)
+  ingest      Ingest a markdown document into workspace memory (chunks by heading)
   query       Semantic search across recorded capsules
   trace       Trace the causal chain of decisions that led to the current state of a file, symbol, or concept
   recall      Recall the story so far (proactive overview)
@@ -111,6 +112,8 @@ pub enum OutputFormat {
     Ansi,
     /// No ANSI colors (useful for piping)
     Plain,
+    /// Machine-readable JSON (stable schema, one object per result)
+    Json,
 }
 
 #[derive(Debug, Subcommand)]
@@ -206,6 +209,10 @@ pub enum Command {
         #[arg(long, default_value_t = false)]
         plain: bool,
 
+        /// Shortcut for `--output json`
+        #[arg(long, default_value_t = false)]
+        json: bool,
+
         /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
         #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
         embed_model: String,
@@ -272,6 +279,10 @@ pub enum Command {
         #[arg(long, default_value_t = false)]
         plain: bool,
 
+        /// Shortcut for `--output json`
+        #[arg(long, default_value_t = false)]
+        json: bool,
+
         /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
         #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
         embed_model: String,
@@ -333,6 +344,10 @@ pub enum Command {
         #[arg(long, default_value_t = false)]
         plain: bool,
 
+        /// Shortcut for `--output json`
+        #[arg(long, default_value_t = false)]
+        json: bool,
+
         /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
         #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
         embed_model: String,
@@ -383,6 +398,10 @@ pub enum Command {
         #[arg(long, default_value_t = false)]
         plain: bool,
 
+        /// Shortcut for `--output json`
+        #[arg(long, default_value_t = false)]
+        json: bool,
+
         /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
         #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
         embed_model: String,
@@ -422,6 +441,10 @@ pub enum Command {
         #[arg(long, default_value_t = false)]
         plain: bool,
 
+        /// Shortcut for `--output json`
+        #[arg(long, default_value_t = false)]
+        json: bool,
+
         /// Workspace path (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
@@ -447,6 +470,10 @@ pub enum Command {
         /// Shortcut for `--output plain`
         #[arg(long, default_value_t = false)]
         plain: bool,
+
+        /// Shortcut for `--output json`
+        #[arg(long, default_value_t = false)]
+        json: bool,
 
         /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
         #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
@@ -481,6 +508,10 @@ pub enum Command {
         /// Shortcut for `--output plain`
         #[arg(long, default_value_t = false)]
         plain: bool,
+
+        /// Shortcut for `--output json`
+        #[arg(long, default_value_t = false)]
+        json: bool,
 
         /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
         #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
@@ -532,6 +563,10 @@ pub enum Command {
         /// Shortcut for `--output plain`
         #[arg(long, default_value_t = false)]
         plain: bool,
+
+        /// Shortcut for `--output json`
+        #[arg(long, default_value_t = false)]
+        json: bool,
 
         /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
         #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
@@ -659,6 +694,28 @@ pub enum Command {
         stdin: bool,
 
         /// Embedding model (fastembed). Default: Xenova/bge-small-en-v1.5
+        #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
+        embed_model: String,
+
+        /// Embedding cache directory (defaults to XDG data dir)
+        #[arg(long, env = "UNLOST_EMBED_CACHE_DIR")]
+        embed_cache_dir: Option<String>,
+    },
+
+    /// Ingest a markdown document into workspace memory (chunks by heading, no LLM required)
+    Ingest {
+        /// One or more markdown file paths to ingest
+        paths: Vec<String>,
+
+        /// Override the capsule category tag (default: cartography)
+        #[arg(long)]
+        category: Option<String>,
+
+        /// Force the global workspace even when inside a project directory
+        #[arg(long, default_value_t = false)]
+        global: bool,
+
+        /// Embedding model (fastembed). Default: BAAI/bge-small-en-v1.5
         #[arg(long, default_value = crate::constants::DEFAULT_EMBED_MODEL)]
         embed_model: String,
 

--- a/src/commands/brief.rs
+++ b/src/commands/brief.rs
@@ -322,27 +322,30 @@ pub async fn run(
         if let Some(pb) = spinner.as_ref() {
             pb.finish_and_clear();
         }
-        // Print raw capsules without LLM narrative
-        for hit in &hits {
-            let cap = &hit.capsule;
-            println!("---");
-            println!("category:  {}", cap.category);
-            if !cap.intent.trim().is_empty() {
-                println!("intent:    {}", cap.intent);
+        if output == OutputFormat::Json {
+            println!("{}", crate::util::hits_to_json_pretty(&hits));
+        } else {
+            for hit in &hits {
+                let cap = &hit.capsule;
+                println!("---");
+                println!("category:  {}", cap.category);
+                if !cap.intent.trim().is_empty() {
+                    println!("intent:    {}", cap.intent);
+                }
+                if !cap.decision.trim().is_empty() {
+                    println!("decision:  {}", cap.decision);
+                }
+                if !cap.rationale.trim().is_empty() {
+                    println!("rationale: {}", cap.rationale);
+                }
+                if !cap.next_steps.is_empty() {
+                    println!("next:      {:?}", cap.next_steps);
+                }
+                println!("symbols:   {:?}", cap.symbols);
+                println!();
             }
-            if !cap.decision.trim().is_empty() {
-                println!("decision:  {}", cap.decision);
-            }
-            if !cap.rationale.trim().is_empty() {
-                println!("rationale: {}", cap.rationale);
-            }
-            if !cap.next_steps.is_empty() {
-                println!("next:      {:?}", cap.next_steps);
-            }
-            println!("symbols:   {:?}", cap.symbols);
             println!();
         }
-        println!();
         return Ok(());
     }
 

--- a/src/commands/challenge.rs
+++ b/src/commands/challenge.rs
@@ -195,27 +195,30 @@ pub async fn run(
         if let Some(pb) = spinner.as_ref() {
             pb.finish_and_clear();
         }
-        // Print raw scored capsules without LLM narrative
-        for hit in &hits {
-            let cap = &hit.capsule;
-            println!("---");
-            println!("category:  {}", cap.category);
-            if !cap.intent.trim().is_empty() {
-                println!("intent:    {}", cap.intent);
+        if output == OutputFormat::Json {
+            println!("{}", crate::util::hits_to_json_pretty(&hits));
+        } else {
+            for hit in &hits {
+                let cap = &hit.capsule;
+                println!("---");
+                println!("category:  {}", cap.category);
+                if !cap.intent.trim().is_empty() {
+                    println!("intent:    {}", cap.intent);
+                }
+                if !cap.decision.trim().is_empty() {
+                    println!("decision:  {}", cap.decision);
+                }
+                if !cap.rationale.trim().is_empty() {
+                    println!("rationale: {}", cap.rationale);
+                }
+                if !cap.next_steps.is_empty() {
+                    println!("next:      {:?}", cap.next_steps);
+                }
+                println!("symbols:   {:?}", cap.symbols);
+                println!();
             }
-            if !cap.decision.trim().is_empty() {
-                println!("decision:  {}", cap.decision);
-            }
-            if !cap.rationale.trim().is_empty() {
-                println!("rationale: {}", cap.rationale);
-            }
-            if !cap.next_steps.is_empty() {
-                println!("next:      {:?}", cap.next_steps);
-            }
-            println!("symbols:   {:?}", cap.symbols);
             println!();
         }
-        println!();
         return Ok(());
     }
 

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -197,27 +197,30 @@ pub async fn run(
         if let Some(pb) = spinner.as_ref() {
             pb.finish_and_clear();
         }
-        // Print raw scored capsules without LLM narrative
-        for hit in &hits {
-            let cap = &hit.capsule;
-            println!("---");
-            println!("category:  {}", cap.category);
-            if !cap.intent.trim().is_empty() {
-                println!("intent:    {}", cap.intent);
+        if output == OutputFormat::Json {
+            println!("{}", crate::util::hits_to_json_pretty(&hits));
+        } else {
+            for hit in &hits {
+                let cap = &hit.capsule;
+                println!("---");
+                println!("category:  {}", cap.category);
+                if !cap.intent.trim().is_empty() {
+                    println!("intent:    {}", cap.intent);
+                }
+                if !cap.decision.trim().is_empty() {
+                    println!("decision:  {}", cap.decision);
+                }
+                if !cap.rationale.trim().is_empty() {
+                    println!("rationale: {}", cap.rationale);
+                }
+                if !cap.next_steps.is_empty() {
+                    println!("next:      {:?}", cap.next_steps);
+                }
+                println!("symbols:   {:?}", cap.symbols);
+                println!();
             }
-            if !cap.decision.trim().is_empty() {
-                println!("decision:  {}", cap.decision);
-            }
-            if !cap.rationale.trim().is_empty() {
-                println!("rationale: {}", cap.rationale);
-            }
-            if !cap.next_steps.is_empty() {
-                println!("next:      {:?}", cap.next_steps);
-            }
-            println!("symbols:   {:?}", cap.symbols);
             println!();
         }
-        println!();
         return Ok(());
     }
 

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -1,0 +1,432 @@
+//! `unlost ingest <file.md>` — chunk a markdown document into capsules.
+//!
+//! Each `##` / `###` heading becomes a capsule with:
+//!   - `category: cartography` (or `cartography:<tag>` from frontmatter)
+//!   - `intent`: the heading text
+//!   - `decision`: the section body
+//!   - `symbols`: code-fence identifiers + [[wiki-links]] + frontmatter symbols
+//!
+//! YAML frontmatter (delimited by `---`) is parsed for:
+//!   - `target`: used as the intent if no heading is present
+//!   - `target_path`: added to symbols
+//!   - `symbols`: extra symbols list
+//!   - `related`: added to symbols
+//!   - `category`: overrides the default `cartography` category tag
+//!
+//! Capsules are inserted into the current workspace's LanceDB store and
+//! appended to `capsules.jsonl`, exactly like `unlost note`.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A section extracted from a markdown document.
+#[derive(Debug)]
+struct Section {
+    /// Heading text (empty string for preamble before first heading)
+    heading: String,
+    /// Section body text
+    body: String,
+    /// Heading level (2 for `##`, 3 for `###`, 0 for preamble)
+    level: usize,
+}
+
+/// Parsed frontmatter from a markdown file.
+#[derive(Debug, Default)]
+struct Frontmatter {
+    target: Option<String>,
+    target_path: Option<String>,
+    symbols: Vec<String>,
+    related: Vec<String>,
+    category_tag: Option<String>,
+}
+
+/// Parse YAML-like frontmatter from the top of a markdown string.
+/// Returns (frontmatter, rest_of_content).
+fn parse_frontmatter(content: &str) -> (Frontmatter, &str) {
+    let content = content.trim_start();
+    if !content.starts_with("---") {
+        return (Frontmatter::default(), content);
+    }
+    let after_open = &content[3..];
+    // Skip optional newline after opening ---
+    let after_open = after_open.trim_start_matches('\n').trim_start_matches('\r');
+    let close = match after_open.find("\n---") {
+        Some(p) => p,
+        None => return (Frontmatter::default(), content),
+    };
+    let frontmatter_text = &after_open[..close];
+    let rest = &after_open[close + 4..]; // skip \n---
+
+    let mut fm = Frontmatter::default();
+    for line in frontmatter_text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, val)) = line.split_once(':') {
+            let key = key.trim();
+            let val = val.trim().trim_matches('"').trim_matches('\'');
+            match key {
+                "target" => fm.target = Some(val.to_string()),
+                "target_path" => fm.target_path = Some(val.to_string()),
+                "category" => fm.category_tag = Some(val.to_string()),
+                "symbols" | "related" => {
+                    // Accept "key: [a, b, c]" or "key: a" (single value)
+                    let vals = parse_yaml_list(val);
+                    if key == "symbols" {
+                        fm.symbols.extend(vals);
+                    } else {
+                        fm.related.extend(vals);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    (fm, rest)
+}
+
+/// Parse a YAML inline list `[a, b, c]` or a bare value `a`.
+fn parse_yaml_list(s: &str) -> Vec<String> {
+    let s = s.trim();
+    if s.starts_with('[') && s.ends_with(']') {
+        let inner = &s[1..s.len() - 1];
+        inner
+            .split(',')
+            .map(|v| v.trim().trim_matches('"').trim_matches('\'').to_string())
+            .filter(|v| !v.is_empty())
+            .collect()
+    } else if !s.is_empty() {
+        vec![s.trim_matches('"').trim_matches('\'').to_string()]
+    } else {
+        vec![]
+    }
+}
+
+/// Split markdown content (with frontmatter already stripped) into sections.
+/// Splits on `##` and `###` headings. Content before the first heading
+/// is returned as a preamble section with an empty heading.
+fn split_sections(content: &str) -> Vec<Section> {
+    let mut sections: Vec<Section> = Vec::new();
+    let mut current_heading = String::new();
+    let mut current_level = 0usize;
+    let mut current_body = String::new();
+
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("### ") {
+            if !current_body.trim().is_empty() || !current_heading.is_empty() {
+                sections.push(Section {
+                    heading: current_heading.clone(),
+                    body: current_body.trim().to_string(),
+                    level: current_level,
+                });
+            }
+            current_heading = rest.trim().to_string();
+            current_level = 3;
+            current_body = String::new();
+        } else if let Some(rest) = line.strip_prefix("## ") {
+            if !current_body.trim().is_empty() || !current_heading.is_empty() {
+                sections.push(Section {
+                    heading: current_heading.clone(),
+                    body: current_body.trim().to_string(),
+                    level: current_level,
+                });
+            }
+            current_heading = rest.trim().to_string();
+            current_level = 2;
+            current_body = String::new();
+        } else {
+            current_body.push_str(line);
+            current_body.push('\n');
+        }
+    }
+
+    // Flush final section
+    if !current_body.trim().is_empty() || !current_heading.is_empty() {
+        sections.push(Section {
+            heading: current_heading,
+            body: current_body.trim().to_string(),
+            level: current_level,
+        });
+    }
+
+    sections
+}
+
+/// Extract symbols from markdown text:
+/// - Code-fence language identifiers: ```rust, ```python, etc.
+/// - Inline backtick tokens that look like identifiers: `MyStruct`, `fn_name`
+/// - [[wiki-links]]
+fn extract_md_symbols(text: &str) -> Vec<String> {
+    let mut symbols: Vec<String> = Vec::new();
+
+    // [[wiki-links]]
+    let mut rest = text;
+    while let Some(start) = rest.find("[[") {
+        let after = &rest[start + 2..];
+        if let Some(end) = after.find("]]") {
+            let link = after[..end].trim();
+            if !link.is_empty() {
+                symbols.push(link.to_string());
+            }
+            rest = &after[end + 2..];
+        } else {
+            break;
+        }
+    }
+
+    // Code-fence language tags: ```rust\n or ```python\n
+    for line in text.lines() {
+        let l = line.trim();
+        if let Some(lang) = l.strip_prefix("```") {
+            let lang = lang.trim();
+            if !lang.is_empty() && lang.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-') {
+                symbols.push(lang.to_string());
+            }
+        }
+    }
+
+    // Inline backtick identifiers: `SomeName` or `some_fn`
+    let mut s = text;
+    while let Some(start) = s.find('`') {
+        let after = &s[start + 1..];
+        if after.starts_with('`') {
+            // Skip `` double-backtick sequences
+            s = &after[1..];
+            continue;
+        }
+        if let Some(end) = after.find('`') {
+            let token = &after[..end];
+            // Only keep identifiers: CamelCase, snake_case, paths with ::
+            let looks_like_ident = !token.is_empty()
+                && token.len() <= 64
+                && token.chars().all(|c| c.is_alphanumeric() || c == '_' || c == ':' || c == '.')
+                && token.chars().next().map(|c| c.is_alphabetic() || c == '_').unwrap_or(false);
+            if looks_like_ident {
+                symbols.push(token.to_string());
+            }
+            s = &after[end + 1..];
+        } else {
+            break;
+        }
+    }
+
+    // Dedup while preserving order
+    let mut seen = std::collections::HashSet::new();
+    symbols.retain(|s| seen.insert(s.clone()));
+
+    symbols
+}
+
+pub async fn run(
+    paths: Vec<String>,
+    category_override: Option<String>,
+    global: bool,
+    embed_model: String,
+    embed_cache_dir: Option<String>,
+) -> anyhow::Result<()> {
+    if paths.is_empty() {
+        println!("Ingest markdown documents into workspace memory.\n");
+        println!("Usage: unlost ingest <file.md> [<file2.md> ...]");
+        println!("\nOptions:");
+        println!("  --category <tag>   Override the category tag (default: cartography)");
+        println!("  --global           Ingest into the global workspace");
+        println!("\nEach ## / ### heading becomes a capsule. Frontmatter fields:");
+        println!("  target, target_path, symbols, related, category");
+        return Ok(());
+    }
+
+    let ws_root = resolve_workspace_root(global)?;
+    let ws = crate::workspace::get_or_create_workspace_paths(&ws_root)?;
+
+    let embedder = crate::embed::load_embedder(
+        &embed_model,
+        embed_cache_dir.as_deref().map(std::path::PathBuf::from),
+        true,
+    )
+    .await?;
+
+    std::fs::create_dir_all(&ws.db_dir)?;
+    let db = lancedb::connect(ws.db_dir.to_string_lossy().as_ref())
+        .execute()
+        .await?;
+    let _ = crate::storage::ensure_capsules_table(&db).await?;
+
+    let ws_label = crate::workspace::workspace_label_by_id(&ws.id)
+        .unwrap_or_else(|| ws.id.clone());
+
+    let mut total_capsules = 0usize;
+
+    for path in &paths {
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("unlost ingest: cannot read {path}: {e}");
+                continue;
+            }
+        };
+
+        let file_name = std::path::Path::new(path)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.clone());
+
+        let (fm, body) = parse_frontmatter(&content);
+        let sections = split_sections(body);
+
+        // Base category: prefer --category flag, then frontmatter, then "cartography"
+        let base_category = category_override
+            .as_deref()
+            .or(fm.category_tag.as_deref())
+            .unwrap_or("cartography");
+
+        // Symbols that apply to the whole document (from frontmatter)
+        let mut doc_symbols: Vec<String> = Vec::new();
+        if let Some(ref tp) = fm.target_path {
+            doc_symbols.push(tp.clone());
+        }
+        doc_symbols.extend(fm.symbols.iter().cloned());
+        doc_symbols.extend(fm.related.iter().cloned());
+
+        // Also extract symbols from the full document text for better retrieval
+        let doc_wide_syms = extract_md_symbols(&content);
+        for s in &doc_wide_syms {
+            if !doc_symbols.contains(s) {
+                doc_symbols.push(s.clone());
+            }
+        }
+
+        let doc_target = fm.target.as_deref().unwrap_or(&file_name);
+
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+
+        let non_empty_sections: Vec<&Section> = sections
+            .iter()
+            .filter(|s| !s.body.trim().is_empty() || !s.heading.is_empty())
+            .collect();
+
+        if non_empty_sections.is_empty() {
+            eprintln!("unlost ingest: {file_name}: no sections found, skipping");
+            continue;
+        }
+
+        for (i, section) in non_empty_sections.iter().enumerate() {
+            // Space capsule timestamps 1ms apart to preserve section order
+            let ts_ms = now_ms + i as i64;
+
+            let intent = if section.heading.is_empty() {
+                // Preamble: use the document target as the intent
+                format!("{doc_target} (overview)")
+            } else {
+                section.heading.clone()
+            };
+
+            // Combine doc-level symbols with section-local symbols
+            let mut section_symbols = doc_symbols.clone();
+            let local_syms = extract_md_symbols(&section.body);
+            for s in &local_syms {
+                if !section_symbols.contains(s) {
+                    section_symbols.push(s.clone());
+                }
+            }
+            // Also add the heading itself as a symbol for direct lookup
+            if !section.heading.is_empty() {
+                section_symbols.push(section.heading.clone());
+            }
+
+            // Category: cartography (or override), optionally with level suffix
+            let category = if section.level == 3 {
+                format!("{base_category}:sub")
+            } else {
+                base_category.to_string()
+            };
+
+            let capsule = crate::IntentCapsule {
+                category,
+                intent: intent.clone(),
+                decision: section.body.clone(),
+                rationale: String::new(),
+                next_steps: Vec::new(),
+                symbols: section_symbols,
+                user_symbols: vec![],
+                failure_mode: crate::types::FailureMode::None,
+                failure_signals: None,
+                extraction_mode: crate::types::ExtractionMode::None,
+                questions: vec![],
+            };
+
+            let source_pointer = ws.root.to_str().map(|p| {
+                format!("ingest+local://{p}/{file_name}#section={i}")
+            });
+
+            let meta = crate::ResponseMeta {
+                source: "ingest".to_string(),
+                upstream_host: "ingest".to_string(),
+                request_path: file_name.clone(),
+                http_status: 0,
+                agent_session_id: None,
+                source_pointer,
+                usage: None,
+            };
+
+            let prior = if i > 0 {
+                non_empty_sections.get(i - 1).map(|s| s.body.as_str())
+            } else {
+                None
+            };
+
+            crate::storage::insert_capsule_row(
+                &db, &embedder, 0, i as u64, ts_ms, &meta,
+                None, None, &capsule,
+                &crate::types::TurnEval::default(),
+                prior, None, None,
+            )
+            .await?;
+
+            let _ = crate::recording::append_capsule_jsonl(
+                &ws.capsules_jsonl, ts_ms, 0, i as u64, &meta, &capsule, None, None,
+            );
+
+            total_capsules += 1;
+        }
+
+        eprintln!(
+            "\x1b[2mingest\x1b[0m · \x1b[36m{ws_label}\x1b[0m · \x1b[1m{file_name}\x1b[0m → {} capsules",
+            non_empty_sections.len()
+        );
+    }
+
+    eprintln!(
+        "\x1b[2m{total_capsules} capsule{} ingested\x1b[0m · queryable now",
+        if total_capsules == 1 { "" } else { "s" }
+    );
+
+    Ok(())
+}
+
+fn resolve_workspace_root(global: bool) -> anyhow::Result<std::path::PathBuf> {
+    if global {
+        let root = crate::workspace::unlost_data_root().join("global");
+        std::fs::create_dir_all(&root)?;
+        return Ok(root);
+    }
+
+    let cwd = std::env::current_dir()?;
+    if let Some(repo_root) = crate::workspace::git_toplevel(&cwd) {
+        return Ok(repo_root);
+    }
+
+    let has_manifest = ["Cargo.toml", "pyproject.toml", "package.json", "go.mod"]
+        .iter()
+        .any(|name| cwd.join(name).exists());
+    if has_manifest {
+        return Ok(cwd);
+    }
+
+    let root = crate::workspace::unlost_data_root().join("global");
+    std::fs::create_dir_all(&root)?;
+    Ok(root)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod anthropic_login;
 pub mod brief;
+pub mod ingest;
 pub mod challenge;
 pub mod mcp;
 pub mod checkpoint;

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -379,7 +379,9 @@ pub async fn run(
                 pb.finish_and_clear();
             }
 
-            if no_llm || facts {
+            if no_llm && output == crate::cli::OutputFormat::Json {
+                println!("{}", crate::util::hits_to_json_pretty(&matches));
+            } else if no_llm || facts {
                 let print_usage = |usage: &crate::types::UsageMeta| {
                     if let Some(provider_id) = usage.provider_id.as_deref() {
                         println!("provider_id: {provider_id}");

--- a/src/commands/recall.rs
+++ b/src/commands/recall.rs
@@ -511,27 +511,30 @@ pub async fn run(
         if let Some(pb) = spinner.as_ref() {
             pb.finish_and_clear();
         }
-        // Print raw capsules without LLM narrative
-        for hit in &hits {
-            let cap = &hit.capsule;
-            println!("---");
-            println!("category:  {}", cap.category);
-            if !cap.intent.trim().is_empty() {
-                println!("intent:    {}", cap.intent);
+        if output == OutputFormat::Json {
+            println!("{}", crate::util::hits_to_json_pretty(&hits));
+        } else {
+            for hit in &hits {
+                let cap = &hit.capsule;
+                println!("---");
+                println!("category:  {}", cap.category);
+                if !cap.intent.trim().is_empty() {
+                    println!("intent:    {}", cap.intent);
+                }
+                if !cap.decision.trim().is_empty() {
+                    println!("decision:  {}", cap.decision);
+                }
+                if !cap.rationale.trim().is_empty() {
+                    println!("rationale: {}", cap.rationale);
+                }
+                if !cap.next_steps.is_empty() {
+                    println!("next:      {:?}", cap.next_steps);
+                }
+                println!("symbols:   {:?}", cap.symbols);
+                println!();
             }
-            if !cap.decision.trim().is_empty() {
-                println!("decision:  {}", cap.decision);
-            }
-            if !cap.rationale.trim().is_empty() {
-                println!("rationale: {}", cap.rationale);
-            }
-            if !cap.next_steps.is_empty() {
-                println!("next:      {:?}", cap.next_steps);
-            }
-            println!("symbols:   {:?}", cap.symbols);
             println!();
         }
-        println!();
         return Ok(());
     }
 

--- a/src/commands/reflect.rs
+++ b/src/commands/reflect.rs
@@ -217,17 +217,20 @@ pub async fn run(
         if let Some(pb) = spinner.as_ref() {
             pb.finish_and_clear();
         }
-        // Print raw turn evaluation data without LLM narrative
-        println!("Turn evaluation data ({} turns):", eval_capsules.len());
-        for hit in &eval_capsules {
-            if let Some(ref eval) = hit.turn_eval {
-                println!("---");
-                println!("session:   {:?}", hit.meta.agent_session_id);
-                println!("category:  {}", hit.capsule.category);
-                println!("eval:      {:?}", eval);
+        if output == crate::cli::OutputFormat::Json {
+            println!("{}", crate::util::hits_to_json_pretty(&eval_capsules));
+        } else {
+            println!("Turn evaluation data ({} turns):", eval_capsules.len());
+            for hit in &eval_capsules {
+                if let Some(ref eval) = hit.turn_eval {
+                    println!("---");
+                    println!("session:   {:?}", hit.meta.agent_session_id);
+                    println!("category:  {}", hit.capsule.category);
+                    println!("eval:      {:?}", eval);
+                }
             }
+            println!();
         }
-        println!();
         return Ok(());
     }
 

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -114,7 +114,11 @@ pub async fn run(
         if let Some(pb) = spinner.as_ref() {
             pb.finish_and_clear();
         }
-        print_raw_chain(output, &chain);
+        if output == OutputFormat::Json {
+            println!("{}", crate::util::hits_to_json_pretty(&chain));
+        } else {
+            print_raw_chain(output, &chain);
+        }
         return Ok(());
     }
 
@@ -166,7 +170,11 @@ pub async fn run(
                 pb.finish_and_clear();
             }
             tracing::warn!(error = ?e, "trace narrative failed; printing raw chain");
-            print_raw_chain(output, &chain);
+            if output == OutputFormat::Json {
+                println!("{}", crate::util::hits_to_json_pretty(&chain));
+            } else {
+                print_raw_chain(output, &chain);
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,11 +98,12 @@ async fn main() -> anyhow::Result<()> {
             facts,
             output,
             plain,
+            json,
             embed_model,
             embed_cache_dir,
             file,
         } => {
-            let output = if plain { OutputFormat::Plain } else { output };
+            let output = if json { OutputFormat::Json } else if plain { OutputFormat::Plain } else { output };
             unlost::commands::query::run(
                 query,
                 limit,
@@ -135,10 +136,11 @@ async fn main() -> anyhow::Result<()> {
             no_llm,
             output,
             plain,
+            json,
             embed_model,
             embed_cache_dir,
         } => {
-            let output = if plain { OutputFormat::Plain } else { output };
+            let output = if json { OutputFormat::Json } else if plain { OutputFormat::Plain } else { output };
             unlost::commands::trace::run(
                 target,
                 seeds,
@@ -183,10 +185,11 @@ async fn main() -> anyhow::Result<()> {
             llm_model,
             output,
             plain,
+            json,
             embed_model,
             embed_cache_dir,
         } => {
-            let output = if plain { OutputFormat::Plain } else { output };
+            let output = if json { OutputFormat::Json } else if plain { OutputFormat::Plain } else { output };
             unlost::commands::brief::run(target, no_llm, llm_model, output, embed_model, embed_cache_dir)
                 .await?;
         }
@@ -198,9 +201,10 @@ async fn main() -> anyhow::Result<()> {
             llm_model,
             output,
             plain,
+            json,
             path,
         } => {
-            let output = if plain { OutputFormat::Plain } else { output };
+            let output = if json { OutputFormat::Json } else if plain { OutputFormat::Plain } else { output };
             unlost::commands::reflect::run(mode, session, since, no_llm, llm_model, output, path)
                 .await?;
         }
@@ -210,10 +214,11 @@ async fn main() -> anyhow::Result<()> {
             llm_model,
             output,
             plain,
+            json,
             embed_model,
             embed_cache_dir,
         } => {
-            let output = if plain { OutputFormat::Plain } else { output };
+            let output = if json { OutputFormat::Json } else if plain { OutputFormat::Plain } else { output };
             unlost::commands::explore::run(query, no_llm, llm_model, output, embed_model, embed_cache_dir)
                 .await?;
         }
@@ -224,10 +229,11 @@ async fn main() -> anyhow::Result<()> {
             llm_model,
             output,
             plain,
+            json,
             embed_model,
             embed_cache_dir,
         } => {
-            let output = if plain { OutputFormat::Plain } else { output };
+            let output = if json { OutputFormat::Json } else if plain { OutputFormat::Plain } else { output };
             unlost::commands::challenge::run(
                 target, deep, no_llm, llm_model, output, embed_model, embed_cache_dir,
             )
@@ -242,10 +248,11 @@ async fn main() -> anyhow::Result<()> {
             llm_model,
             output,
             plain,
+            json,
             embed_model,
             embed_cache_dir,
         } => {
-            let output = if plain { OutputFormat::Plain } else { output };
+            let output = if json { OutputFormat::Json } else if plain { OutputFormat::Plain } else { output };
             unlost::commands::thread::run(
                 topic,
                 limit,
@@ -270,10 +277,11 @@ async fn main() -> anyhow::Result<()> {
             llm_model,
             output,
             plain,
+            json,
             embed_model,
             embed_cache_dir,
         } => {
-            let output = if plain { OutputFormat::Plain } else { output };
+            let output = if json { OutputFormat::Json } else if plain { OutputFormat::Plain } else { output };
             unlost::commands::recall::run(
                 target,
                 limit,
@@ -350,6 +358,16 @@ async fn main() -> anyhow::Result<()> {
                 text, source, global, stdin, embed_model, embed_cache_dir,
             )
             .await?;
+        }
+        Command::Ingest {
+            paths,
+            category,
+            global,
+            embed_model,
+            embed_cache_dir,
+        } => {
+            unlost::commands::ingest::run(paths, category, global, embed_model, embed_cache_dir)
+                .await?;
         }
         Command::Model { command } => {
             unlost::commands::model::run(command).await?;

--- a/src/narrative.rs
+++ b/src/narrative.rs
@@ -426,9 +426,9 @@ pub(crate) fn render_narrative(output: OutputFormat, s: &str) -> String {
     let s = crate::util::strip_llm_boilerplate(s.trim().to_string());
 
     match output {
-        OutputFormat::Plain => s.trim().to_string(),
+        OutputFormat::Plain | OutputFormat::Json => s.trim().to_string(),
         OutputFormat::Ansi => {
-            // Dim “tips” lines so they read as guidance, not facts.
+            // Dim "tips" lines so they read as guidance, not facts.
             // We intentionally skip backtick-coloring inside dimmed lines, so dim stays consistent.
             let wrap_width = 80usize;
             let mut out = String::with_capacity(s.len() + 64);
@@ -1409,7 +1409,7 @@ pub(crate) fn render_brief(output: OutputFormat, s: &str) -> String {
     ];
 
     match output {
-        OutputFormat::Plain => s.trim().to_string(),
+        OutputFormat::Plain | OutputFormat::Json => s.trim().to_string(),
         OutputFormat::Ansi => {
             let wrap_width = 80usize;
             let mut out = String::with_capacity(s.len() + 128);
@@ -1488,7 +1488,7 @@ pub(crate) fn render_structured(output: OutputFormat, s: &str) -> String {
     ];
 
     match output {
-        OutputFormat::Plain => s.trim().to_string(),
+        OutputFormat::Plain | OutputFormat::Json => s.trim().to_string(),
         OutputFormat::Ansi => {
             let mut out = String::with_capacity(s.len() + 256);
             let mut first = true;
@@ -1904,7 +1904,7 @@ pub(crate) fn render_reflect(output: OutputFormat, mode: crate::cli::ReflectMode
 
     let s = crate::util::strip_llm_boilerplate(s.trim().to_string());
 
-    if output == OutputFormat::Plain {
+    if output == OutputFormat::Plain || output == OutputFormat::Json {
         return s;
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -442,3 +442,76 @@ mod tests {
         );
     }
 }
+
+// ============================================================================
+// JSON output types — stable schema for harness / agent consumption
+// ============================================================================
+
+/// Stable JSON representation of a single capsule hit.
+/// Emitted by `--no-llm --output json` (or `--json`) on all retrieval commands.
+/// Schema is intentionally flat: one object per capsule, no nesting beyond arrays.
+#[derive(serde::Serialize)]
+pub struct CapsuleJson {
+    pub id: String,
+    pub ts_ms: i64,
+    /// RFC3339 UTC timestamp (convenience copy of ts_ms)
+    pub time_utc: Option<String>,
+    pub source: String,
+    pub category: String,
+    pub intent: String,
+    pub decision: String,
+    pub rationale: String,
+    pub next_steps: Vec<String>,
+    pub symbols: Vec<String>,
+    pub failure_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_signals: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_pointer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distance: Option<f32>,
+}
+
+impl CapsuleJson {
+    pub fn from_hit(hit: &crate::CapsuleHit) -> Self {
+        use chrono::{SecondsFormat, TimeZone};
+        let time_utc = chrono::Utc
+            .timestamp_millis_opt(hit.ts_ms)
+            .single()
+            .map(|dt| dt.to_rfc3339_opts(SecondsFormat::Secs, true));
+        let failure_mode = format!("{:?}", hit.capsule.failure_mode)
+            .to_lowercase()
+            .replace("failuremode::", "");
+        CapsuleJson {
+            id: hit.id.clone(),
+            ts_ms: hit.ts_ms,
+            time_utc,
+            source: hit.meta.source.clone(),
+            category: hit.capsule.category.clone(),
+            intent: hit.capsule.intent.clone(),
+            decision: hit.capsule.decision.clone(),
+            rationale: hit.capsule.rationale.clone(),
+            next_steps: hit.capsule.next_steps.clone(),
+            symbols: hit.capsule.symbols.clone(),
+            failure_mode,
+            failure_signals: hit.capsule.failure_signals.clone(),
+            agent_session_id: hit.meta.agent_session_id.clone(),
+            source_pointer: hit.meta.source_pointer.clone(),
+            distance: if hit.distance == 0.0 { None } else { Some(hit.distance) },
+        }
+    }
+}
+
+/// Serialize a list of capsule hits to a compact JSON array string.
+pub fn hits_to_json(hits: &[crate::CapsuleHit]) -> String {
+    let items: Vec<CapsuleJson> = hits.iter().map(CapsuleJson::from_hit).collect();
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// Serialize a list of capsule hits to a pretty-printed JSON array string.
+pub fn hits_to_json_pretty(hits: &[crate::CapsuleHit]) -> String {
+    let items: Vec<CapsuleJson> = hits.iter().map(CapsuleJson::from_hit).collect();
+    serde_json::to_string_pretty(&items).unwrap_or_else(|_| "[]".to_string())
+}


### PR DESCRIPTION
## Summary
- Added \`--output json\` / \`--json\` shortcut to all retrieval commands — stable schema, no LLM required when combined with \`--no-llm\`
- Added \`unlost ingest <file.md>\` — chunks markdown by heading into capsules, parses frontmatter, extracts wiki-links and code identifiers as symbols, tags \`category: cartography\` by default
- Both features require no LLM — usable on machines without an API key

## Changelog
- **\`--output json\` / \`--json\` flag**: All retrieval commands now accept \`--output json\`. Combined with \`--no-llm\`, produces a stable JSON array of capsule objects. Schema: \`id\`, \`ts_ms\`, \`time_utc\`, \`source\`, \`category\`, \`intent\`, \`decision\`, \`rationale\`, \`next_steps\`, \`symbols\`, \`failure_mode\`, \`agent_session_id\`, \`source_pointer\`, \`distance\`.
- **\`unlost ingest <file.md>\`**: Chunks markdown by \`##\`/\`###\` heading into capsules. Parses YAML frontmatter, extracts \`[[wiki-links]]\`, code-fence tags, and backtick identifiers as symbols. Tags \`category: cartography\` by default. No LLM required.